### PR TITLE
feat: add elder/family roles, phone login, restructure user management

### DIFF
--- a/backend/app/api/v1/endpoints/auth.py
+++ b/backend/app/api/v1/endpoints/auth.py
@@ -53,6 +53,7 @@ async def login(
 
 @router.get("/me")
 async def get_me(
+    db: AsyncSession = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
     """Return current authenticated user info with permissions."""
@@ -72,6 +73,28 @@ async def get_me(
         "roles": role_names,
         "permissions": sorted(permissions),
     }
+
+    # Add elder_id for elder/family roles
+    if "elder" in role_names:
+        from app.repositories.elder import ElderRepository
+        elder = await ElderRepository.get_by_user_id(db, current_user.id)
+        if elder:
+            data["elder_id"] = elder.id
+    elif "family" in role_names:
+        try:
+            from app.models.family_member import FamilyMember
+            from sqlalchemy import select
+            stmt = select(FamilyMember).where(
+                FamilyMember.user_id == current_user.id,
+                FamilyMember.deleted_at.is_(None),
+            )
+            result = await db.execute(stmt)
+            fm = result.scalar_one_or_none()
+            if fm:
+                data["elder_id"] = fm.elder_id
+        except ImportError:
+            pass
+
     return success_response(data)
 
 

--- a/backend/app/api/v1/endpoints/elders.py
+++ b/backend/app/api/v1/endpoints/elders.py
@@ -9,10 +9,12 @@ from typing import Optional
 from fastapi import APIRouter, Depends, UploadFile, File, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.deps import get_db, require_permission
+from app.core.deps import get_current_user, get_db, require_permission
+from app.models.user import User
 from app.schemas.elder import (
     AccountStatusUpdate,
     ElderCreate,
+    ElderResponse,
     ElderUpdate,
 )
 from app.schemas.health_archive import (
@@ -23,8 +25,11 @@ from app.schemas.health_archive import (
 )
 from app.services.elder import ElderService
 from app.services.health_archive import HealthArchiveService
+from app.services.invite_code import InviteCodeService
 from app.utils.pagination import PaginationParams
 from app.utils.response import (
+    BUSINESS_VALIDATION_FAILED,
+    FORBIDDEN,
     NOT_FOUND,
     PARAM_ERROR,
     FILE_STORAGE_ERROR,
@@ -35,6 +40,59 @@ from app.utils.response import (
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
+
+
+# ==================== Elder Self-Service (must be before /{elder_id}) ====================
+
+
+@router.get("/me")
+async def get_elder_self(
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_permission("elder:self_read")),
+):
+    """Get the current elder's own profile."""
+    from app.repositories.elder import ElderRepository
+    elder = await ElderRepository.get_by_user_id(db, current_user.id)
+    if elder is None:
+        return error_response(NOT_FOUND, "未找到关联的老人档案")
+    return success_response(ElderResponse.model_validate(elder).model_dump())
+
+
+@router.get("/me/family")
+async def get_elder_family(
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_permission("elder:self_read")),
+):
+    """Get family members linked to the current elder."""
+    from app.repositories.elder import ElderRepository
+    elder = await ElderRepository.get_by_user_id(db, current_user.id)
+    if elder is None:
+        return error_response(NOT_FOUND, "未找到关联的老人档案")
+
+    # Query family members
+    from sqlalchemy import select
+    # Import FamilyMember - may not exist yet if family backend hasn't merged
+    try:
+        from app.models.family_member import FamilyMember
+        stmt = (
+            select(FamilyMember)
+            .where(FamilyMember.elder_id == elder.id, FamilyMember.deleted_at.is_(None))
+        )
+        result = await db.execute(stmt)
+        members = result.scalars().all()
+        data = [
+            {
+                "id": m.id,
+                "user_id": m.user_id,
+                "relationship": m.relationship,
+                "created_at": m.created_at.isoformat() if m.created_at else None,
+            }
+            for m in members
+        ]
+    except ImportError:
+        data = []
+
+    return success_response(data)
 
 
 # ==================== Elder CRUD ====================
@@ -147,6 +205,103 @@ async def update_account_status(
     if not result:
         return error_response(NOT_FOUND, "Elder not found")
     return success_response(message="Account status updated")
+
+
+# ==================== Account Activation & Invite Codes ====================
+
+
+@router.post("/{elder_id}/activate-account")
+async def activate_elder_account(
+    elder_id: int,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_permission("elder:update")),
+):
+    """Create a user account for an elder, enabling them to log in."""
+    result = await ElderService.activate_account(db, elder_id)
+    if isinstance(result, str):
+        return error_response(BUSINESS_VALIDATION_FAILED, result)
+    return success_response(result, message="账户激活成功")
+
+
+@router.post("/{elder_id}/invite-code")
+async def generate_invite_code(
+    elder_id: int,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Generate an invite code for family member registration."""
+    # Check authorization: admin/doctor with elder:invite OR the elder themselves
+    from app.repositories.elder import ElderRepository
+    elder = await ElderRepository.get_by_id(db, elder_id)
+    if elder is None:
+        return error_response(NOT_FOUND, "老人档案不存在")
+
+    user_permissions = set()
+    for ur in current_user.user_roles:
+        for rp in ur.role.role_permissions:
+            user_permissions.add(rp.permission.code)
+
+    is_self = elder.user_id == current_user.id
+    if not is_self and "elder:invite" not in user_permissions:
+        return error_response(FORBIDDEN, "无权操作")
+
+    if elder.user_id is None:
+        return error_response(BUSINESS_VALIDATION_FAILED, "请先激活老人账户")
+
+    result = await InviteCodeService.generate_code(db, elder_id)
+    return success_response(result.model_dump())
+
+
+@router.get("/{elder_id}/invite-code")
+async def get_invite_code(
+    elder_id: int,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Get active invite code for an elder."""
+    from app.repositories.elder import ElderRepository
+    elder = await ElderRepository.get_by_id(db, elder_id)
+    if elder is None:
+        return error_response(NOT_FOUND, "老人档案不存在")
+
+    user_permissions = set()
+    for ur in current_user.user_roles:
+        for rp in ur.role.role_permissions:
+            user_permissions.add(rp.permission.code)
+
+    is_self = elder.user_id == current_user.id
+    if not is_self and "elder:invite" not in user_permissions:
+        return error_response(FORBIDDEN, "无权操作")
+
+    result = await InviteCodeService.get_active_code(db, elder_id)
+    if result is None:
+        return success_response(None, message="暂无有效邀请码")
+    return success_response(result.model_dump())
+
+
+@router.delete("/{elder_id}/invite-code")
+async def revoke_invite_code(
+    elder_id: int,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Revoke active invite codes for an elder."""
+    from app.repositories.elder import ElderRepository
+    elder = await ElderRepository.get_by_id(db, elder_id)
+    if elder is None:
+        return error_response(NOT_FOUND, "老人档案不存在")
+
+    user_permissions = set()
+    for ur in current_user.user_roles:
+        for rp in ur.role.role_permissions:
+            user_permissions.add(rp.permission.code)
+
+    is_self = elder.user_id == current_user.id
+    if not is_self and "elder:invite" not in user_permissions:
+        return error_response(FORBIDDEN, "无权操作")
+
+    await InviteCodeService.revoke_code(db, elder_id)
+    return success_response(message="邀请码已撤销")
 
 
 # ==================== Health Records ====================

--- a/backend/app/api/v1/endpoints/family.py
+++ b/backend/app/api/v1/endpoints/family.py
@@ -1,0 +1,68 @@
+"""Family member endpoints -- registration, self-service."""
+
+import logging
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.deps import get_db, require_permission
+from app.models.user import User
+from app.schemas.family_member import FamilyRegisterRequest
+from app.services.family_member import FamilyMemberService
+from app.services.invite_code import InviteCodeService
+from app.utils.response import (
+    BUSINESS_VALIDATION_FAILED,
+    NOT_FOUND,
+    error_response,
+    success_response,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+@router.get("/validate-code/{code}")
+async def validate_invite_code(
+    code: str,
+    db: AsyncSession = Depends(get_db),
+):
+    """Validate an invite code (public, no auth required)."""
+    result = await InviteCodeService.validate_code(db, code)
+    return success_response(result.model_dump())
+
+
+@router.post("/register")
+async def register_family_member(
+    body: FamilyRegisterRequest,
+    db: AsyncSession = Depends(get_db),
+):
+    """Self-register as a family member using an invite code (public)."""
+    result = await FamilyMemberService.register(db, body)
+    if isinstance(result, str):
+        return error_response(BUSINESS_VALIDATION_FAILED, result)
+    return success_response(result, message="注册成功")
+
+
+@router.get("/me")
+async def get_family_self(
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_permission("family:read")),
+):
+    """Get current family member's profile and linked elder info."""
+    info = await FamilyMemberService.get_my_info(db, current_user.id)
+    if info is None:
+        return error_response(NOT_FOUND, "未找到家属信息")
+    return success_response(info.model_dump())
+
+
+@router.get("/elder")
+async def get_family_elder(
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_permission("family:read")),
+):
+    """Get the linked elder's info for the current family member."""
+    info = await FamilyMemberService.get_linked_elder_info(db, current_user.id)
+    if info is None:
+        return error_response(NOT_FOUND, "未找到关联的老人信息")
+    return success_response(info.model_dump())

--- a/backend/app/api/v1/endpoints/family.py
+++ b/backend/app/api/v1/endpoints/family.py
@@ -10,6 +10,7 @@ from app.models.user import User
 from app.schemas.family_member import FamilyRegisterRequest
 from app.services.family_member import FamilyMemberService
 from app.services.invite_code import InviteCodeService
+from app.utils.pagination import PaginationParams
 from app.utils.response import (
     BUSINESS_VALIDATION_FAILED,
     NOT_FOUND,
@@ -20,6 +21,17 @@ from app.utils.response import (
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
+
+
+@router.get("/members")
+async def list_family_members(
+    pagination: PaginationParams = Depends(),
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_permission("user:manage")),
+):
+    """List all family members (admin only)."""
+    result = await FamilyMemberService.list_all_members(db, pagination)
+    return success_response(result.model_dump())
 
 
 @router.get("/validate-code/{code}")

--- a/backend/app/api/v1/endpoints/users.py
+++ b/backend/app/api/v1/endpoints/users.py
@@ -27,11 +27,12 @@ router = APIRouter()
 async def list_users(
     pagination: PaginationParams = Depends(),
     status: Optional[str] = Query(None, pattern="^(active|disabled)$"),
+    role: Optional[str] = Query(None),
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(require_permission("user:manage")),
 ):
     """Return a paginated list of users."""
-    result = await UserService.list_users(db, pagination, status)
+    result = await UserService.list_users(db, pagination, status, role=role)
     return success_response(result.model_dump())
 
 

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -25,3 +25,7 @@ api_router.include_router(followups.router, prefix="/followups", tags=["随访�
 api_router.include_router(interventions.router, prefix="/interventions", tags=["干预记录"])
 api_router.include_router(dashboard.router, prefix="/dashboard", tags=["工作台"])
 api_router.include_router(analytics.router, prefix="/analytics", tags=["数据分析"])
+
+# ===== Family Role routes (feat/family-role-backend) =====
+from app.api.v1.endpoints import family
+api_router.include_router(family.router, prefix="/family", tags=["家属管理"])

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -20,3 +20,6 @@ from app.models.alert import Alert  # noqa: F401
 from app.models.followup import Followup, FollowupRecord  # noqa: F401
 from app.models.intervention import Intervention  # noqa: F401
 from app.models.analytics import AnalyticsJob, ElderRiskProfile, DashboardSnapshot  # noqa: F401
+
+# ===== Elder & Family Role models =====
+from app.models.invite_code import ElderInviteCode  # noqa: F401

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -20,3 +20,7 @@ from app.models.alert import Alert  # noqa: F401
 from app.models.followup import Followup, FollowupRecord  # noqa: F401
 from app.models.intervention import Intervention  # noqa: F401
 from app.models.analytics import AnalyticsJob, ElderRiskProfile, DashboardSnapshot  # noqa: F401
+
+# ===== Family Role models (feat/family-role-backend) =====
+from app.models.invite_code import ElderInviteCode  # noqa: F401
+from app.models.family_member import FamilyMember  # noqa: F401

--- a/backend/app/models/elder.py
+++ b/backend/app/models/elder.py
@@ -9,7 +9,8 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 from app.models.base import BaseModel
 
 if TYPE_CHECKING:
-    pass
+    from app.models.user import User
+    from app.models.invite_code import ElderInviteCode
 
 
 class Elder(BaseModel):
@@ -17,6 +18,9 @@ class Elder(BaseModel):
 
     __tablename__ = "elders"
 
+    user_id: Mapped[Optional[int]] = mapped_column(
+        BigInteger, ForeignKey("users.id", ondelete="SET NULL"), nullable=True, unique=True
+    )
     name: Mapped[str] = mapped_column(String(64), nullable=False)
     gender: Mapped[str] = mapped_column(String(16), nullable=False, default="unknown")
     birth_date: Mapped[Optional[date]] = mapped_column(Date, nullable=True)
@@ -44,6 +48,13 @@ class Elder(BaseModel):
         back_populates="elder",
         cascade="all, delete-orphan",
         lazy="selectin",
+    )
+    user: Mapped[Optional["User"]] = relationship("User", foreign_keys=[user_id], lazy="selectin")
+    invite_codes: Mapped[list["ElderInviteCode"]] = relationship(
+        "ElderInviteCode",
+        back_populates="elder",
+        cascade="all, delete-orphan",
+        lazy="noload",
     )
 
 

--- a/backend/app/models/elder.py
+++ b/backend/app/models/elder.py
@@ -9,7 +9,7 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 from app.models.base import BaseModel
 
 if TYPE_CHECKING:
-    pass
+    from app.models.invite_code import ElderInviteCode
 
 
 class Elder(BaseModel):
@@ -44,6 +44,11 @@ class Elder(BaseModel):
         back_populates="elder",
         cascade="all, delete-orphan",
         lazy="selectin",
+    )
+    invite_codes: Mapped[list["ElderInviteCode"]] = relationship(
+        "ElderInviteCode",
+        back_populates="elder",
+        lazy="noload",
     )
 
 

--- a/backend/app/models/family_member.py
+++ b/backend/app/models/family_member.py
@@ -3,7 +3,7 @@
 from typing import TYPE_CHECKING, Optional
 
 from sqlalchemy import BigInteger, ForeignKey, String
-from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy.orm import Mapped, mapped_column, relationship as sa_relationship
 
 from app.models.base import BaseModel
 
@@ -25,6 +25,6 @@ class FamilyMember(BaseModel):
     )
     relationship: Mapped[str] = mapped_column(String(32), nullable=False, default="")
 
-    # Relationships
-    user: Mapped["User"] = relationship("User", foreign_keys=[user_id], lazy="selectin")
-    elder: Mapped["Elder"] = relationship("Elder", foreign_keys=[elder_id], lazy="selectin")
+    # ORM relationships
+    user: Mapped["User"] = sa_relationship("User", foreign_keys=[user_id], lazy="selectin")
+    elder: Mapped["Elder"] = sa_relationship("Elder", foreign_keys=[elder_id], lazy="selectin")

--- a/backend/app/models/family_member.py
+++ b/backend/app/models/family_member.py
@@ -1,0 +1,30 @@
+"""FamilyMember ORM model."""
+
+from typing import TYPE_CHECKING, Optional
+
+from sqlalchemy import BigInteger, ForeignKey, String
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.models.base import BaseModel
+
+if TYPE_CHECKING:
+    from app.models.user import User
+    from app.models.elder import Elder
+
+
+class FamilyMember(BaseModel):
+    """Family member linked to an elder."""
+
+    __tablename__ = "family_members"
+
+    user_id: Mapped[int] = mapped_column(
+        BigInteger, ForeignKey("users.id"), nullable=False
+    )
+    elder_id: Mapped[int] = mapped_column(
+        BigInteger, ForeignKey("elders.id"), nullable=False
+    )
+    relationship: Mapped[str] = mapped_column(String(32), nullable=False, default="")
+
+    # Relationships
+    user: Mapped["User"] = relationship("User", foreign_keys=[user_id], lazy="selectin")
+    elder: Mapped["Elder"] = relationship("Elder", foreign_keys=[elder_id], lazy="selectin")

--- a/backend/app/models/invite_code.py
+++ b/backend/app/models/invite_code.py
@@ -1,0 +1,29 @@
+"""ElderInviteCode ORM model."""
+
+from datetime import datetime
+from typing import TYPE_CHECKING, Optional
+
+from sqlalchemy import BigInteger, DateTime, ForeignKey, Integer, String
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.models.base import BaseModel
+
+if TYPE_CHECKING:
+    from app.models.elder import Elder
+
+
+class ElderInviteCode(BaseModel):
+    """Invite code for family member registration."""
+
+    __tablename__ = "elder_invite_codes"
+
+    elder_id: Mapped[int] = mapped_column(
+        BigInteger, ForeignKey("elders.id"), nullable=False
+    )
+    code: Mapped[str] = mapped_column(String(16), nullable=False, unique=True)
+    expires_at: Mapped[datetime] = mapped_column(DateTime, nullable=False)
+    used_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    max_uses: Mapped[int] = mapped_column(Integer, nullable=False, default=3)
+
+    # Relationships
+    elder: Mapped["Elder"] = relationship("Elder", back_populates="invite_codes")

--- a/backend/app/models/invite_code.py
+++ b/backend/app/models/invite_code.py
@@ -1,0 +1,28 @@
+"""ElderInviteCode ORM model."""
+
+from datetime import datetime
+from typing import TYPE_CHECKING, Optional
+
+from sqlalchemy import BigInteger, DateTime, ForeignKey, Integer, String
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.models.base import BaseModel
+
+if TYPE_CHECKING:
+    from app.models.elder import Elder
+
+
+class ElderInviteCode(BaseModel):
+    """Invite code for family member registration."""
+
+    __tablename__ = "elder_invite_codes"
+
+    elder_id: Mapped[int] = mapped_column(
+        BigInteger, ForeignKey("elders.id"), nullable=False
+    )
+    code: Mapped[str] = mapped_column(String(16), nullable=False, unique=True)
+    expires_at: Mapped[datetime] = mapped_column(DateTime, nullable=False)
+    used_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    max_uses: Mapped[int] = mapped_column(Integer, nullable=False, default=3)
+
+    elder: Mapped["Elder"] = relationship("Elder", back_populates="invite_codes")

--- a/backend/app/repositories/elder.py
+++ b/backend/app/repositories/elder.py
@@ -29,6 +29,17 @@ class ElderRepository:
         return result.scalar_one_or_none()
 
     @staticmethod
+    async def get_by_user_id(db: AsyncSession, user_id: int) -> Optional[Elder]:
+        """Get an elder by their linked user account ID."""
+        stmt = (
+            select(Elder)
+            .options(selectinload(Elder.tags))
+            .where(Elder.user_id == user_id, Elder.deleted_at.is_(None))
+        )
+        result = await db.execute(stmt)
+        return result.scalar_one_or_none()
+
+    @staticmethod
     async def get_list(
         db: AsyncSession,
         pagination: PaginationParams,

--- a/backend/app/repositories/elder.py
+++ b/backend/app/repositories/elder.py
@@ -51,7 +51,7 @@ class ElderRepository:
         """Get paginated list of elders with optional filters."""
         stmt = (
             select(Elder)
-            .options(selectinload(Elder.tags))
+            .options(selectinload(Elder.tags), selectinload(Elder.user))
             .where(Elder.deleted_at.is_(None))
         )
 

--- a/backend/app/repositories/family_member.py
+++ b/backend/app/repositories/family_member.py
@@ -1,0 +1,66 @@
+"""Repository layer for family member data access."""
+
+import logging
+from typing import Optional
+
+from sqlalchemy import select, func
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from app.models.family_member import FamilyMember
+
+logger = logging.getLogger(__name__)
+
+
+class FamilyMemberRepository:
+    """Data access operations for family members."""
+
+    @staticmethod
+    async def get_by_user_id(db: AsyncSession, user_id: int) -> Optional[FamilyMember]:
+        """Get family member by user account ID."""
+        stmt = (
+            select(FamilyMember)
+            .options(selectinload(FamilyMember.elder))
+            .where(FamilyMember.user_id == user_id, FamilyMember.deleted_at.is_(None))
+        )
+        result = await db.execute(stmt)
+        return result.scalar_one_or_none()
+
+    @staticmethod
+    async def get_by_elder_id(db: AsyncSession, elder_id: int) -> list[FamilyMember]:
+        """Get all family members linked to an elder."""
+        stmt = (
+            select(FamilyMember)
+            .options(selectinload(FamilyMember.user))
+            .where(FamilyMember.elder_id == elder_id, FamilyMember.deleted_at.is_(None))
+        )
+        result = await db.execute(stmt)
+        return list(result.scalars().all())
+
+    @staticmethod
+    async def count_by_elder_id(db: AsyncSession, elder_id: int) -> int:
+        """Count active family members for an elder."""
+        stmt = (
+            select(func.count())
+            .select_from(FamilyMember)
+            .where(FamilyMember.elder_id == elder_id, FamilyMember.deleted_at.is_(None))
+        )
+        result = await db.execute(stmt)
+        return result.scalar() or 0
+
+    @staticmethod
+    async def create(
+        db: AsyncSession,
+        user_id: int,
+        elder_id: int,
+        relationship: str = "",
+    ) -> FamilyMember:
+        """Create a family member record."""
+        member = FamilyMember(
+            user_id=user_id,
+            elder_id=elder_id,
+            relationship=relationship,
+        )
+        db.add(member)
+        await db.flush()
+        return member

--- a/backend/app/repositories/family_member.py
+++ b/backend/app/repositories/family_member.py
@@ -49,6 +49,53 @@ class FamilyMemberRepository:
         return result.scalar() or 0
 
     @staticmethod
+    async def count_by_elder_ids(
+        db: AsyncSession, elder_ids: list[int]
+    ) -> dict[int, int]:
+        """Batch count family members grouped by elder_id."""
+        if not elder_ids:
+            return {}
+        stmt = (
+            select(FamilyMember.elder_id, func.count())
+            .where(
+                FamilyMember.elder_id.in_(elder_ids),
+                FamilyMember.deleted_at.is_(None),
+            )
+            .group_by(FamilyMember.elder_id)
+        )
+        result = await db.execute(stmt)
+        return {row[0]: row[1] for row in result.all()}
+
+    @staticmethod
+    async def get_all_paginated(
+        db: AsyncSession,
+        pagination,
+    ):
+        """Get paginated list of all family members with user and elder loaded."""
+        from app.models.user import User
+
+        stmt = (
+            select(FamilyMember)
+            .options(
+                selectinload(FamilyMember.user),
+                selectinload(FamilyMember.elder),
+            )
+            .where(FamilyMember.deleted_at.is_(None))
+        )
+
+        if pagination.keyword:
+            kw = f"%{pagination.keyword}%"
+            stmt = stmt.outerjoin(User, FamilyMember.user_id == User.id).where(
+                (User.username.ilike(kw))
+                | (User.real_name.ilike(kw))
+                | (User.phone.ilike(kw))
+            )
+
+        from app.utils.pagination import paginate
+        from app.schemas.family_member import FamilyMemberAdminResponse
+        return await paginate(stmt, db, pagination, FamilyMemberAdminResponse)
+
+    @staticmethod
     async def create(
         db: AsyncSession,
         user_id: int,

--- a/backend/app/repositories/invite_code.py
+++ b/backend/app/repositories/invite_code.py
@@ -1,0 +1,112 @@
+"""Repository layer for invite code data access."""
+
+import logging
+from datetime import datetime, timezone
+from typing import Optional
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.invite_code import ElderInviteCode
+
+logger = logging.getLogger(__name__)
+
+
+class InviteCodeRepository:
+    """Data access operations for invite codes."""
+
+    @staticmethod
+    async def get_active_by_elder_id(
+        db: AsyncSession, elder_id: int
+    ) -> Optional[ElderInviteCode]:
+        """Get the active (non-expired, not exhausted) invite code for an elder."""
+        now = datetime.now(timezone.utc)
+        stmt = (
+            select(ElderInviteCode)
+            .where(
+                ElderInviteCode.elder_id == elder_id,
+                ElderInviteCode.deleted_at.is_(None),
+                ElderInviteCode.expires_at > now,
+            )
+            .order_by(ElderInviteCode.created_at.desc())
+            .limit(1)
+        )
+        result = await db.execute(stmt)
+        code = result.scalar_one_or_none()
+        if code and code.used_count >= code.max_uses:
+            return None
+        return code
+
+    @staticmethod
+    async def get_by_code(db: AsyncSession, code: str) -> Optional[ElderInviteCode]:
+        """Get invite code by code string."""
+        stmt = (
+            select(ElderInviteCode)
+            .where(
+                ElderInviteCode.code == code,
+                ElderInviteCode.deleted_at.is_(None),
+            )
+        )
+        result = await db.execute(stmt)
+        return result.scalar_one_or_none()
+
+    @staticmethod
+    async def get_by_code_for_update(db: AsyncSession, code: str) -> Optional[ElderInviteCode]:
+        """Get invite code with row lock for registration."""
+        stmt = (
+            select(ElderInviteCode)
+            .where(
+                ElderInviteCode.code == code,
+                ElderInviteCode.deleted_at.is_(None),
+            )
+            .with_for_update()
+        )
+        result = await db.execute(stmt)
+        return result.scalar_one_or_none()
+
+    @staticmethod
+    async def create(
+        db: AsyncSession,
+        elder_id: int,
+        code: str,
+        expires_at: datetime,
+        max_uses: int = 3,
+    ) -> ElderInviteCode:
+        """Create a new invite code."""
+        invite = ElderInviteCode(
+            elder_id=elder_id,
+            code=code,
+            expires_at=expires_at,
+            max_uses=max_uses,
+        )
+        db.add(invite)
+        await db.flush()
+        return invite
+
+    @staticmethod
+    async def increment_used_count(db: AsyncSession, code_id: int) -> None:
+        """Increment the used_count for an invite code."""
+        stmt = select(ElderInviteCode).where(ElderInviteCode.id == code_id).with_for_update()
+        result = await db.execute(stmt)
+        invite = result.scalar_one_or_none()
+        if invite:
+            invite.used_count += 1
+            await db.flush()
+
+    @staticmethod
+    async def soft_delete_by_elder_id(db: AsyncSession, elder_id: int) -> bool:
+        """Soft delete all invite codes for an elder."""
+        now = datetime.now(timezone.utc)
+        stmt = (
+            select(ElderInviteCode)
+            .where(
+                ElderInviteCode.elder_id == elder_id,
+                ElderInviteCode.deleted_at.is_(None),
+            )
+        )
+        result = await db.execute(stmt)
+        codes = result.scalars().all()
+        for code in codes:
+            code.deleted_at = now
+        await db.flush()
+        return len(codes) > 0

--- a/backend/app/repositories/invite_code.py
+++ b/backend/app/repositories/invite_code.py
@@ -1,0 +1,60 @@
+"""Repository layer for invite code data access."""
+
+import logging
+from typing import Optional
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.invite_code import ElderInviteCode
+
+logger = logging.getLogger(__name__)
+
+
+class InviteCodeRepository:
+    """Data access operations for elder invite codes."""
+
+    @staticmethod
+    async def get_by_code_for_update(
+        db: AsyncSession, code: str
+    ) -> Optional[ElderInviteCode]:
+        """Get an invite code with row-level lock for atomic updates."""
+        stmt = (
+            select(ElderInviteCode)
+            .where(
+                ElderInviteCode.code == code,
+                ElderInviteCode.deleted_at.is_(None),
+            )
+            .with_for_update()
+        )
+        result = await db.execute(stmt)
+        return result.scalar_one_or_none()
+
+    @staticmethod
+    async def get_by_code(
+        db: AsyncSession, code: str
+    ) -> Optional[ElderInviteCode]:
+        """Get an invite code by its code string."""
+        stmt = (
+            select(ElderInviteCode)
+            .where(
+                ElderInviteCode.code == code,
+                ElderInviteCode.deleted_at.is_(None),
+            )
+        )
+        result = await db.execute(stmt)
+        return result.scalar_one_or_none()
+
+    @staticmethod
+    async def increment_used_count(db: AsyncSession, code_id: int) -> None:
+        """Increment the used_count of an invite code."""
+        stmt = (
+            select(ElderInviteCode)
+            .where(ElderInviteCode.id == code_id)
+            .with_for_update()
+        )
+        result = await db.execute(stmt)
+        invite = result.scalar_one_or_none()
+        if invite:
+            invite.used_count += 1
+            await db.flush()

--- a/backend/app/repositories/user.py
+++ b/backend/app/repositories/user.py
@@ -54,16 +54,36 @@ class UserRepository:
         return result.scalar_one_or_none()
 
     @staticmethod
+    async def get_by_phone(db: AsyncSession, phone: str) -> Optional[User]:
+        """Load a user by phone number with eager-loaded roles and permissions."""
+        stmt = (
+            select(User)
+            .options(
+                selectinload(User.user_roles)
+                .selectinload(UserRole.role)
+                .selectinload(Role.role_permissions)
+                .selectinload(RolePermission.permission)
+            )
+            .where(User.phone == phone, User.deleted_at.is_(None))
+        )
+        result = await db.execute(stmt)
+        return result.scalars().first()
+
+    @staticmethod
     async def get_list(
         db: AsyncSession,
         pagination: PaginationParams,
         status_filter: Optional[str] = None,
+        role_name: Optional[str] = None,
     ) -> PaginatedData:
         """Return a paginated list of users with eager-loaded roles."""
         base_stmt = select(User).where(User.deleted_at.is_(None))
 
         if status_filter:
             base_stmt = base_stmt.where(User.status == status_filter)
+
+        if role_name:
+            base_stmt = base_stmt.join(UserRole, User.id == UserRole.user_id).join(Role, UserRole.role_id == Role.id).where(Role.name == role_name)
 
         if pagination.keyword:
             keyword = f"%{pagination.keyword}%"

--- a/backend/app/schemas/elder.py
+++ b/backend/app/schemas/elder.py
@@ -13,7 +13,7 @@ class ElderCreate(BaseModel):
     gender: str = "unknown"
     birth_date: Optional[date] = None
     id_card: Optional[str] = None
-    phone: Optional[str] = None
+    phone: str
     address: Optional[str] = None
     emergency_contact_name: Optional[str] = None
     emergency_contact_phone: Optional[str] = None
@@ -54,6 +54,8 @@ class ElderResponse(BaseModel):
     account_status: str
     emergency_contact_name: Optional[str] = None
     emergency_contact_phone: Optional[str] = None
+    username: Optional[str] = None
+    family_count: int = 0
     tags: list[str] = []
     created_at: Optional[datetime] = None
 

--- a/backend/app/schemas/family_member.py
+++ b/backend/app/schemas/family_member.py
@@ -1,0 +1,55 @@
+"""Pydantic schemas for family member registration and responses."""
+
+from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class FamilyRegisterRequest(BaseModel):
+    """Family member self-registration request."""
+
+    invite_code: str = Field(..., min_length=1, max_length=16)
+    real_name: str = Field(..., min_length=1, max_length=64)
+    phone: str = Field(..., min_length=1, max_length=20)
+    password: str = Field(..., min_length=6, max_length=128)
+    relationship: str = Field(default="", max_length=32)
+    captcha_token: str = Field(..., min_length=1)
+    session_id: str = Field(..., min_length=1)
+
+
+class FamilyMemberResponse(BaseModel):
+    """Family member info response."""
+
+    id: int
+    user_id: int
+    elder_id: int
+    relationship: str
+    real_name: str = ""
+    phone: str = ""
+    elder_name: str = ""
+    created_at: Optional[datetime] = None
+
+    model_config = {"from_attributes": True}
+
+
+class FamilyElderInfoResponse(BaseModel):
+    """Elder info visible to family members."""
+
+    elder_id: int
+    name: str
+    gender: str
+    birth_date: Optional[str] = None
+    phone: str = ""
+    address: str = ""
+    emergency_contact_name: str = ""
+    emergency_contact_phone: str = ""
+    tags: list[str] = []
+
+
+class InviteCodeValidationResponse(BaseModel):
+    """Response for invite code validation."""
+
+    valid: bool
+    elder_name: str = ""
+    message: str = ""

--- a/backend/app/schemas/family_member.py
+++ b/backend/app/schemas/family_member.py
@@ -3,7 +3,7 @@
 from datetime import datetime
 from typing import Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
 class FamilyRegisterRequest(BaseModel):
@@ -45,6 +45,40 @@ class FamilyElderInfoResponse(BaseModel):
     emergency_contact_name: str = ""
     emergency_contact_phone: str = ""
     tags: list[str] = []
+
+
+class FamilyMemberAdminResponse(BaseModel):
+    """Admin view of a family member with user and elder info."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    user_id: int
+    elder_id: int
+    relationship: str
+    username: str = ""
+    real_name: str = ""
+    phone: str = ""
+    elder_name: str = ""
+    created_at: Optional[datetime] = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def extract_nested(cls, data):
+        """Extract user and elder fields from ORM relationships."""
+        if hasattr(data, "user") and data.user:
+            return {
+                "id": data.id,
+                "user_id": data.user_id,
+                "elder_id": data.elder_id,
+                "relationship": data.relationship,
+                "username": data.user.username,
+                "real_name": data.user.real_name,
+                "phone": data.user.phone or "",
+                "elder_name": data.elder.name if data.elder else "",
+                "created_at": data.created_at,
+            }
+        return data
 
 
 class InviteCodeValidationResponse(BaseModel):

--- a/backend/app/schemas/invite_code.py
+++ b/backend/app/schemas/invite_code.py
@@ -1,0 +1,22 @@
+"""Pydantic schemas for invite codes."""
+
+from datetime import datetime
+from pydantic import BaseModel
+
+
+class InviteCodeResponse(BaseModel):
+    """Response for invite code."""
+    code: str
+    expires_at: datetime
+    used_count: int
+    max_uses: int
+    remaining_slots: int
+
+    model_config = {"from_attributes": True}
+
+
+class InviteCodeValidateResponse(BaseModel):
+    """Response for public invite code validation."""
+    valid: bool
+    elder_name: str = ""
+    remaining_slots: int = 0

--- a/backend/app/services/auth.py
+++ b/backend/app/services/auth.py
@@ -69,8 +69,10 @@ class AuthService:
             await AuthService._record_login(db, None, ip, user_agent, "captcha_invalid")
             return "验证码错误"
 
-        # Find user
+        # Find user by username or phone
         user = await UserRepository.get_by_username(db, username)
+        if user is None:
+            user = await UserRepository.get_by_phone(db, username)
         if user is None:
             await AuthService._record_login(db, None, ip, user_agent, "user_not_found")
             return "用户名或密码错误"

--- a/backend/app/services/elder.py
+++ b/backend/app/services/elder.py
@@ -101,3 +101,56 @@ class ElderService:
     async def get_tags(db: AsyncSession) -> list[str]:
         """Get all distinct elder tags."""
         return await ElderRepository.get_all_tags(db)
+
+    @staticmethod
+    async def activate_account(db: AsyncSession, elder_id: int) -> dict | str:
+        """Create a user account for an elder and link it.
+
+        Returns dict with username and password on success, or error string.
+        """
+        elder = await ElderRepository.get_by_id(db, elder_id)
+        if elder is None:
+            return "老人档案不存在"
+        if elder.user_id is not None:
+            return "该老人已有关联账户"
+
+        # Generate username from phone or elder_<id>
+        username = f"elder_{elder.id}" if not elder.phone else elder.phone
+
+        # Check username uniqueness
+        from app.repositories.user import UserRepository
+        existing = await UserRepository.get_by_username(db, username)
+        if existing:
+            username = f"elder_{elder.id}"
+            existing = await UserRepository.get_by_username(db, username)
+            if existing:
+                return "用户名已存在，请联系管理员"
+
+        # Generate random password
+        alphabet = string.ascii_letters + string.digits
+        plain_password = "".join(secrets.choice(alphabet) for _ in range(12))
+        hashed = hash_password(plain_password)
+
+        # Create user
+        from app.models.user import User, UserRole
+        user = User(
+            username=username,
+            real_name=elder.name,
+            phone=elder.phone,
+            password_hash=hashed,
+            status="active",
+        )
+        db.add(user)
+        await db.flush()
+
+        # Assign elder role (role_id=3)
+        user_role = UserRole(user_id=user.id, role_id=3)
+        db.add(user_role)
+
+        # Link elder to user
+        elder.user_id = user.id
+        elder.account_status = "active"
+
+        await db.commit()
+        logger.info("Elder account activated: elder_id=%s user_id=%s", elder_id, user.id)
+        return {"username": username, "password": plain_password}

--- a/backend/app/services/elder.py
+++ b/backend/app/services/elder.py
@@ -44,10 +44,35 @@ class ElderService:
         risk_level: str | None = None,
     ):
         """List elders with pagination and filters."""
-        return await ElderRepository.get_list(
+        result = await ElderRepository.get_list(
             db, pagination, gender=gender, tag=tag,
             account_status=account_status, risk_level=risk_level,
         )
+
+        # Enrich with username and family_count
+        if result.items:
+            elder_ids = [item.id for item in result.items]
+
+            # Batch fetch family counts
+            from app.repositories.family_member import FamilyMemberRepository
+            family_counts = await FamilyMemberRepository.count_by_elder_ids(db, elder_ids)
+
+            # Batch fetch usernames via Elder -> user_id -> User
+            from sqlalchemy import select as sa_select
+            from app.models.elder import Elder
+            from app.models.user import User
+
+            stmt = sa_select(Elder.id, User.username).outerjoin(
+                User, Elder.user_id == User.id
+            ).where(Elder.id.in_(elder_ids))
+            rows = await db.execute(stmt)
+            username_map = {r[0]: r[1] for r in rows.all()}
+
+            for item in result.items:
+                item.username = username_map.get(item.id)
+                item.family_count = family_counts.get(item.id, 0)
+
+        return result
 
     @staticmethod
     async def update_elder(

--- a/backend/app/services/family_member.py
+++ b/backend/app/services/family_member.py
@@ -27,6 +27,11 @@ class FamilyMemberService:
     """Family member business operations."""
 
     @staticmethod
+    async def list_all_members(db: AsyncSession, pagination):
+        """List all family members for admin view."""
+        return await FamilyMemberRepository.get_all_paginated(db, pagination)
+
+    @staticmethod
     async def register(
         db: AsyncSession, data: FamilyRegisterRequest
     ) -> dict | str:

--- a/backend/app/services/family_member.py
+++ b/backend/app/services/family_member.py
@@ -1,0 +1,150 @@
+"""Business logic for family member registration and management."""
+
+import logging
+from datetime import datetime, timezone
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.redis_client import redis_delete, redis_get
+from app.core.security import hash_password
+from app.models.user import User, UserRole
+from app.repositories.elder import ElderRepository
+from app.repositories.family_member import FamilyMemberRepository
+from app.repositories.invite_code import InviteCodeRepository
+from app.repositories.user import UserRepository
+from app.schemas.family_member import (
+    FamilyElderInfoResponse,
+    FamilyMemberResponse,
+    FamilyRegisterRequest,
+)
+
+logger = logging.getLogger(__name__)
+
+MAX_FAMILY_MEMBERS = 3
+
+
+class FamilyMemberService:
+    """Family member business operations."""
+
+    @staticmethod
+    async def register(
+        db: AsyncSession, data: FamilyRegisterRequest
+    ) -> dict | str:
+        """Register a new family member using an invite code.
+
+        Returns dict with username on success, or error string.
+        """
+        # Validate slider captcha token (same pattern as AuthService.login)
+        token_key = f"captcha_token:{data.captcha_token}"
+        stored_session = await redis_get(token_key)
+        if stored_session is None:
+            return "验证码已过期"
+        await redis_delete(token_key)
+        if stored_session != data.session_id:
+            return "验证码错误"
+
+        # Lock and validate invite code
+        invite = await InviteCodeRepository.get_by_code_for_update(db, data.invite_code)
+        if invite is None:
+            return "邀请码不存在"
+
+        now = datetime.now(timezone.utc)
+        if invite.expires_at.replace(tzinfo=timezone.utc) <= now:
+            return "邀请码已过期"
+        if invite.used_count >= invite.max_uses:
+            return "邀请码已用完"
+
+        # Check elder exists
+        elder = await ElderRepository.get_by_id(db, invite.elder_id)
+        if elder is None:
+            return "关联的老人档案不存在"
+
+        # Check family member count
+        count = await FamilyMemberRepository.count_by_elder_id(db, invite.elder_id)
+        if count >= MAX_FAMILY_MEMBERS:
+            return "该老人已达到最大家属数量限制（3人）"
+
+        # Check phone uniqueness as username
+        username = data.phone
+        existing = await UserRepository.get_by_username(db, username)
+        if existing:
+            return "该手机号已注册"
+
+        # Create user account
+        user = User(
+            username=username,
+            real_name=data.real_name,
+            phone=data.phone,
+            password_hash=hash_password(data.password),
+            status="active",
+        )
+        db.add(user)
+        await db.flush()
+
+        # Assign family role (role_id=4)
+        user_role = UserRole(user_id=user.id, role_id=4)
+        db.add(user_role)
+
+        # Create family member record
+        await FamilyMemberRepository.create(
+            db,
+            user_id=user.id,
+            elder_id=invite.elder_id,
+            relationship=data.relationship,
+        )
+
+        # Increment invite code usage
+        await InviteCodeRepository.increment_used_count(db, invite.id)
+
+        await db.commit()
+
+        logger.info(
+            "Family member registered: user_id=%s elder_id=%s",
+            user.id,
+            invite.elder_id,
+        )
+        return {"username": username, "elder_name": elder.name}
+
+    @staticmethod
+    async def get_my_info(
+        db: AsyncSession, user_id: int
+    ) -> FamilyMemberResponse | None:
+        """Get family member info by user ID."""
+        member = await FamilyMemberRepository.get_by_user_id(db, user_id)
+        if member is None:
+            return None
+        return FamilyMemberResponse(
+            id=member.id,
+            user_id=member.user_id,
+            elder_id=member.elder_id,
+            relationship=member.relationship,
+            real_name=member.user.real_name if member.user else "",
+            phone=member.user.phone if member.user else "",
+            elder_name=member.elder.name if member.elder else "",
+            created_at=member.created_at,
+        )
+
+    @staticmethod
+    async def get_linked_elder_info(
+        db: AsyncSession, user_id: int
+    ) -> FamilyElderInfoResponse | None:
+        """Get the linked elder's info for a family member."""
+        member = await FamilyMemberRepository.get_by_user_id(db, user_id)
+        if member is None:
+            return None
+
+        elder = await ElderRepository.get_by_id(db, member.elder_id)
+        if elder is None:
+            return None
+
+        return FamilyElderInfoResponse(
+            elder_id=elder.id,
+            name=elder.name,
+            gender=elder.gender,
+            birth_date=elder.birth_date.isoformat() if elder.birth_date else None,
+            phone=elder.phone,
+            address=elder.address,
+            emergency_contact_name=elder.emergency_contact_name,
+            emergency_contact_phone=elder.emergency_contact_phone,
+            tags=[t.tag_name for t in elder.tags],
+        )

--- a/backend/app/services/invite_code.py
+++ b/backend/app/services/invite_code.py
@@ -1,0 +1,48 @@
+"""Business logic for invite code operations."""
+
+import logging
+from datetime import datetime, timezone
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.repositories.elder import ElderRepository
+from app.repositories.invite_code import InviteCodeRepository
+from app.schemas.family_member import InviteCodeValidationResponse
+
+logger = logging.getLogger(__name__)
+
+
+class InviteCodeService:
+    """Invite code business operations."""
+
+    @staticmethod
+    async def validate_code(
+        db: AsyncSession, code: str
+    ) -> InviteCodeValidationResponse:
+        """Validate an invite code and return elder info if valid."""
+        invite = await InviteCodeRepository.get_by_code(db, code)
+        if invite is None:
+            return InviteCodeValidationResponse(
+                valid=False, message="邀请码不存在"
+            )
+
+        now = datetime.now(timezone.utc)
+        if invite.expires_at.replace(tzinfo=timezone.utc) <= now:
+            return InviteCodeValidationResponse(
+                valid=False, message="邀请码已过期"
+            )
+
+        if invite.used_count >= invite.max_uses:
+            return InviteCodeValidationResponse(
+                valid=False, message="邀请码已用完"
+            )
+
+        elder = await ElderRepository.get_by_id(db, invite.elder_id)
+        if elder is None:
+            return InviteCodeValidationResponse(
+                valid=False, message="关联的老人档案不存在"
+            )
+
+        return InviteCodeValidationResponse(
+            valid=True, elder_name=elder.name, message="邀请码有效"
+        )

--- a/backend/app/services/invite_code.py
+++ b/backend/app/services/invite_code.py
@@ -1,0 +1,112 @@
+"""Business logic for invite code management."""
+
+import logging
+import secrets
+import string
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.repositories.invite_code import InviteCodeRepository
+from app.schemas.invite_code import InviteCodeResponse, InviteCodeValidateResponse
+
+logger = logging.getLogger(__name__)
+
+CODE_LENGTH = 8
+CODE_EXPIRY_DAYS = 7
+MAX_FAMILY_MEMBERS = 3
+
+
+def _generate_code() -> str:
+    """Generate an 8-character alphanumeric invite code."""
+    alphabet = string.ascii_uppercase + string.digits
+    # Remove ambiguous characters
+    alphabet = alphabet.replace("O", "").replace("0", "").replace("I", "").replace("1", "")
+    return "".join(secrets.choice(alphabet) for _ in range(CODE_LENGTH))
+
+
+class InviteCodeService:
+    """Invite code business operations."""
+
+    @staticmethod
+    async def generate_code(db: AsyncSession, elder_id: int) -> InviteCodeResponse:
+        """Generate or return existing active invite code for an elder."""
+        # Check for existing active code
+        existing = await InviteCodeRepository.get_active_by_elder_id(db, elder_id)
+        if existing:
+            return InviteCodeResponse(
+                code=existing.code,
+                expires_at=existing.expires_at,
+                used_count=existing.used_count,
+                max_uses=existing.max_uses,
+                remaining_slots=existing.max_uses - existing.used_count,
+            )
+
+        # Generate new code
+        code = _generate_code()
+        expires_at = datetime.now(timezone.utc) + timedelta(days=CODE_EXPIRY_DAYS)
+        invite = await InviteCodeRepository.create(
+            db, elder_id=elder_id, code=code, expires_at=expires_at
+        )
+        await db.commit()
+        await db.refresh(invite)
+        logger.info("Invite code generated: elder_id=%s code=%s", elder_id, code)
+        return InviteCodeResponse(
+            code=invite.code,
+            expires_at=invite.expires_at,
+            used_count=invite.used_count,
+            max_uses=invite.max_uses,
+            remaining_slots=invite.max_uses - invite.used_count,
+        )
+
+    @staticmethod
+    async def get_active_code(db: AsyncSession, elder_id: int) -> InviteCodeResponse | None:
+        """Get active invite code for an elder."""
+        existing = await InviteCodeRepository.get_active_by_elder_id(db, elder_id)
+        if not existing:
+            return None
+        return InviteCodeResponse(
+            code=existing.code,
+            expires_at=existing.expires_at,
+            used_count=existing.used_count,
+            max_uses=existing.max_uses,
+            remaining_slots=existing.max_uses - existing.used_count,
+        )
+
+    @staticmethod
+    async def validate_code(db: AsyncSession, code: str) -> InviteCodeValidateResponse:
+        """Validate an invite code (public endpoint)."""
+        invite = await InviteCodeRepository.get_by_code(db, code)
+        if not invite:
+            return InviteCodeValidateResponse(valid=False)
+
+        now = datetime.now(timezone.utc)
+        if invite.expires_at.replace(tzinfo=timezone.utc) <= now:
+            return InviteCodeValidateResponse(valid=False)
+        if invite.used_count >= invite.max_uses:
+            return InviteCodeValidateResponse(valid=False)
+
+        # Load elder name for display (masked)
+        from app.repositories.elder import ElderRepository
+        elder = await ElderRepository.get_by_id(db, invite.elder_id)
+        if not elder:
+            return InviteCodeValidateResponse(valid=False)
+
+        # Mask elder name: keep first char, mask the rest
+        name = elder.name
+        masked_name = name[0] + "*" * (len(name) - 1) if len(name) > 1 else name
+
+        return InviteCodeValidateResponse(
+            valid=True,
+            elder_name=masked_name,
+            remaining_slots=invite.max_uses - invite.used_count,
+        )
+
+    @staticmethod
+    async def revoke_code(db: AsyncSession, elder_id: int) -> bool:
+        """Revoke all active invite codes for an elder."""
+        result = await InviteCodeRepository.soft_delete_by_elder_id(db, elder_id)
+        if result:
+            await db.commit()
+            logger.info("Invite codes revoked: elder_id=%s", elder_id)
+        return result

--- a/backend/app/services/user.py
+++ b/backend/app/services/user.py
@@ -44,9 +44,10 @@ class UserService:
         db: AsyncSession,
         pagination: PaginationParams,
         status: Optional[str] = None,
+        role: Optional[str] = None,
     ):
         """Return a paginated list of users."""
-        return await UserRepository.get_list(db, pagination, status)
+        return await UserRepository.get_list(db, pagination, status, role_name=role)
 
     @staticmethod
     async def update_user(

--- a/deploy/mysql/init/001_init.sql
+++ b/deploy/mysql/init/001_init.sql
@@ -459,3 +459,72 @@ INSERT INTO `role_permissions` (`role_id`, `permission_id`) VALUES
 
 -- Assign admin role to admin user
 INSERT INTO `user_roles` (`user_id`, `role_id`) VALUES (1, 1);
+
+-- ============================================================
+-- 11. Elder & Family Role Support
+-- ============================================================
+
+-- Add user_id to elders for unified auth
+ALTER TABLE `elders` ADD COLUMN `user_id` BIGINT UNSIGNED DEFAULT NULL AFTER `id`;
+ALTER TABLE `elders` ADD UNIQUE KEY `uk_user_id` (`user_id`);
+ALTER TABLE `elders` ADD CONSTRAINT `fk_elders_user` FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON DELETE SET NULL;
+
+-- Invite codes for family member registration
+CREATE TABLE IF NOT EXISTS `elder_invite_codes` (
+    `id`         BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    `elder_id`   BIGINT UNSIGNED NOT NULL,
+    `code`       VARCHAR(16) NOT NULL,
+    `expires_at` DATETIME NOT NULL,
+    `used_count` INT UNSIGNED NOT NULL DEFAULT 0,
+    `max_uses`   INT UNSIGNED NOT NULL DEFAULT 3,
+    `created_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `updated_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    `deleted_at` DATETIME DEFAULT NULL,
+    UNIQUE KEY `uk_code` (`code`),
+    INDEX `idx_elder_id` (`elder_id`),
+    CONSTRAINT `fk_invite_codes_elder` FOREIGN KEY (`elder_id`) REFERENCES `elders`(`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- Family members linked to elders
+CREATE TABLE IF NOT EXISTS `family_members` (
+    `id`           BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    `user_id`      BIGINT UNSIGNED NOT NULL,
+    `elder_id`     BIGINT UNSIGNED NOT NULL,
+    `relationship` VARCHAR(32) NOT NULL DEFAULT '',
+    `created_at`   DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `updated_at`   DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    `deleted_at`   DATETIME DEFAULT NULL,
+    UNIQUE KEY `uk_user_elder` (`user_id`, `elder_id`),
+    INDEX `idx_elder_id` (`elder_id`),
+    CONSTRAINT `fk_family_user` FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON DELETE CASCADE,
+    CONSTRAINT `fk_family_elder` FOREIGN KEY (`elder_id`) REFERENCES `elders`(`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- New roles
+INSERT INTO `roles` (`id`, `name`, `display_name`) VALUES
+(3, 'elder',  '老人'),
+(4, 'family', '家属');
+
+-- New permissions
+INSERT INTO `permissions` (`id`, `code`, `name`, `description`) VALUES
+(22, 'elder:invite',    '生成邀请码',       '为老人生成家属邀请码'),
+(23, 'family:read',     '查看关联老人',     '家属查看关联老人的信息'),
+(24, 'elder:self_read', '老人查看个人信息', '老人查看自己的健康预警等信息');
+
+-- Elder role permissions
+INSERT INTO `role_permissions` (`role_id`, `permission_id`) VALUES
+(3, 1),   -- auth:login
+(3, 24),  -- elder:self_read
+(3, 22);  -- elder:invite
+
+-- Family role permissions
+INSERT INTO `role_permissions` (`role_id`, `permission_id`) VALUES
+(4, 1),   -- auth:login
+(4, 23);  -- family:read
+
+-- Admin and doctor get elder:invite
+INSERT INTO `role_permissions` (`role_id`, `permission_id`) VALUES
+(1, 22),  -- admin: elder:invite
+(1, 23),  -- admin: family:read
+(1, 24),  -- admin: elder:self_read
+(2, 22);  -- doctor: elder:invite

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,13 +1,39 @@
+import { useEffect, useState } from 'react';
 import { BrowserRouter } from 'react-router-dom';
-import { ConfigProvider } from 'antd';
+import { ConfigProvider, Spin } from 'antd';
 import zhCN from 'antd/locale/zh_CN';
 import dayjs from 'dayjs';
 import 'dayjs/locale/zh-cn';
 import AppRouter from './router';
+import { useAuthStore } from './store/auth';
 
 dayjs.locale('zh-cn');
 
 function App() {
+  const token = useAuthStore((state) => state.token);
+  const user = useAuthStore((state) => state.user);
+  const fetchUser = useAuthStore((state) => state.fetchUser);
+  const [initializing, setInitializing] = useState(!!token && !user);
+
+  useEffect(() => {
+    if (token && !user) {
+      fetchUser()
+        .catch(() => {
+          // Token invalid — clear it so user sees login
+          useAuthStore.getState().logout();
+        })
+        .finally(() => setInitializing(false));
+    }
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  if (initializing) {
+    return (
+      <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100vh' }}>
+        <Spin size="large" />
+      </div>
+    );
+  }
+
   return (
     <ConfigProvider
       locale={zhCN}

--- a/frontend/src/api/elderPortal.ts
+++ b/frontend/src/api/elderPortal.ts
@@ -1,0 +1,36 @@
+import http from './http';
+
+/** Get elder's own profile */
+export function getElderSelf() {
+  return http.get('/elders/me');
+}
+
+/** Get elder's family members */
+export function getElderFamily() {
+  return http.get('/elders/me/family');
+}
+
+/** Get active invite code */
+export function getInviteCode(elderId: number) {
+  return http.get(`/elders/${elderId}/invite-code`);
+}
+
+/** Generate invite code */
+export function generateInviteCode(elderId: number) {
+  return http.post(`/elders/${elderId}/invite-code`);
+}
+
+/** Revoke invite code */
+export function revokeInviteCode(elderId: number) {
+  return http.delete(`/elders/${elderId}/invite-code`);
+}
+
+/** Get elder health records (reuse from elders API) */
+export function getElderHealthRecords(elderId: number, params?: Record<string, unknown>) {
+  return http.get(`/elders/${elderId}/health-records`, { params });
+}
+
+/** Get elder alerts */
+export function getElderAlerts(params?: Record<string, unknown>) {
+  return http.get('/alerts', { params });
+}

--- a/frontend/src/api/elders.ts
+++ b/frontend/src/api/elders.ts
@@ -49,6 +49,10 @@ export function updateElderAccountStatus(
   return http.post(`/elders/${elderId}/account-status`, { account_status });
 }
 
+export function activateElderAccount(elderId: number) {
+  return http.post(`/elders/${elderId}/activate-account`);
+}
+
 // --- Tags ---
 
 export function getElderTags(): Promise<ApiResponse<ElderTag[]>> {

--- a/frontend/src/api/family.ts
+++ b/frontend/src/api/family.ts
@@ -1,0 +1,39 @@
+import http from './http';
+
+/** Validate invite code (public, no auth) */
+export function validateInviteCode(code: string) {
+  return http.get(`/family/validate-code/${code}`);
+}
+
+/** Register family member (public, no auth) */
+export function registerFamily(data: {
+  invite_code: string;
+  real_name: string;
+  phone: string;
+  password: string;
+  relationship: string;
+  captcha_token: string;
+  session_id: string;
+}) {
+  return http.post('/family/register', data);
+}
+
+/** Get family member's own info */
+export function getFamilySelf() {
+  return http.get('/family/me');
+}
+
+/** Get linked elder info */
+export function getFamilyElder() {
+  return http.get('/family/elder');
+}
+
+/** Get elder's health records (for family viewing) */
+export function getElderHealthRecords(elderId: number, params?: Record<string, unknown>) {
+  return http.get(`/elders/${elderId}/health-records`, { params });
+}
+
+/** Get elder's alerts */
+export function getElderAlerts(params?: Record<string, unknown>) {
+  return http.get('/alerts', { params });
+}

--- a/frontend/src/api/family.ts
+++ b/frontend/src/api/family.ts
@@ -1,4 +1,11 @@
 import http from './http';
+import type { ApiResponse, PaginatedData, PaginationParams } from '../types/common';
+import type { FamilyMemberAdmin } from '../types/family';
+
+/** List all family members (admin) */
+export function getFamilyMembers(params: PaginationParams): Promise<ApiResponse<PaginatedData<FamilyMemberAdmin>>> {
+  return http.get('/family/members', { params });
+}
 
 /** Validate invite code (public, no auth) */
 export function validateInviteCode(code: string) {

--- a/frontend/src/api/users.ts
+++ b/frontend/src/api/users.ts
@@ -2,7 +2,7 @@ import http from './http';
 import type { ApiResponse, PaginatedData, PaginationParams } from '../types/common';
 import type { User, UserCreate, UserUpdate } from '../types/user';
 
-export function getUsers(params: PaginationParams): Promise<ApiResponse<PaginatedData<User>>> {
+export function getUsers(params: PaginationParams & { role?: string }): Promise<ApiResponse<PaginatedData<User>>> {
   return http.get('/users', { params });
 }
 

--- a/frontend/src/layouts/BasicLayout.tsx
+++ b/frontend/src/layouts/BasicLayout.tsx
@@ -9,7 +9,7 @@ import {
   MedicineBoxOutlined,
   FileSearchOutlined,
   UserOutlined,
-  SettingOutlined,
+  HeartOutlined,
   LogoutOutlined,
   MenuFoldOutlined,
   MenuUnfoldOutlined,
@@ -88,27 +88,24 @@ const BasicLayout: React.FC = () => {
       });
     }
 
-    items.push({
-      key: '/accounts',
-      icon: <UserOutlined />,
-      label: '账户管理',
-      children: [
-        { key: '/accounts/elders', label: '老人账户' },
-        { key: '/accounts/personal', label: '个人账户' },
-      ],
-    });
-
-    if (hasAnyPermission(['user:manage', 'role:manage'])) {
+    if (hasAnyPermission(['user:manage'])) {
       items.push({
-        key: '/system',
-        icon: <SettingOutlined />,
-        label: '系统管理',
-        children: [
-          { key: '/system/users', label: '用户管理' },
-          { key: '/system/roles', label: '角色管理' },
-        ],
+        key: '/doctors',
+        icon: <MedicineBoxOutlined />,
+        label: '医生管理',
+      });
+      items.push({
+        key: '/family-members',
+        icon: <HeartOutlined />,
+        label: '家属管理',
       });
     }
+
+    items.push({
+      key: '/accounts/personal',
+      icon: <UserOutlined />,
+      label: '个人账户',
+    });
 
     return items;
   }, [hasAnyPermission]);
@@ -126,8 +123,6 @@ const BasicLayout: React.FC = () => {
     const path = location.pathname;
     if (path.startsWith('/elders')) return ['/elders'];
     if (path.startsWith('/followups')) return ['/followups'];
-    if (path.startsWith('/accounts')) return ['/accounts'];
-    if (path.startsWith('/system')) return ['/system'];
     return [];
   }, [location.pathname]);
 

--- a/frontend/src/layouts/ElderLayout.tsx
+++ b/frontend/src/layouts/ElderLayout.tsx
@@ -1,0 +1,152 @@
+import React, { useMemo } from 'react';
+import { Outlet, useNavigate, useLocation } from 'react-router-dom';
+import { Layout, Menu, Button, Dropdown, theme } from 'antd';
+import {
+  HomeOutlined,
+  UsergroupAddOutlined,
+  UserOutlined,
+  LogoutOutlined,
+  MenuFoldOutlined,
+  MenuUnfoldOutlined,
+} from '@ant-design/icons';
+import type { MenuProps } from 'antd';
+import { useAuthStore } from '../store/auth';
+import { useAppStore } from '../store/app';
+
+const { Header, Sider, Content } = Layout;
+
+type MenuItem = Required<MenuProps>['items'][number];
+
+const ElderLayout: React.FC = () => {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { user, logout } = useAuthStore();
+  const { sidebarCollapsed, toggleSidebar } = useAppStore();
+  const { token: themeToken } = theme.useToken();
+
+  const menuItems = useMemo<MenuItem[]>(() => {
+    return [
+      {
+        key: '/elder',
+        icon: <HomeOutlined />,
+        label: '首页',
+      },
+      {
+        key: '/elder/invite',
+        icon: <UsergroupAddOutlined />,
+        label: '邀请家属',
+      },
+      {
+        key: '/elder/personal',
+        icon: <UserOutlined />,
+        label: '个人账户',
+      },
+    ];
+  }, []);
+
+  const selectedKeys = useMemo(() => {
+    return [location.pathname];
+  }, [location.pathname]);
+
+  const handleMenuClick: MenuProps['onClick'] = ({ key }) => {
+    navigate(key);
+  };
+
+  const handleLogout = async () => {
+    await logout();
+    navigate('/login');
+  };
+
+  const userMenuItems: MenuProps['items'] = [
+    {
+      key: 'personal',
+      icon: <UserOutlined />,
+      label: '个人账户',
+      onClick: () => navigate('/elder/personal'),
+    },
+    { type: 'divider' },
+    {
+      key: 'logout',
+      icon: <LogoutOutlined />,
+      label: '退出登录',
+      onClick: handleLogout,
+    },
+  ];
+
+  return (
+    <Layout style={{ minHeight: '100vh' }}>
+      <Sider
+        trigger={null}
+        collapsible
+        collapsed={sidebarCollapsed}
+        width={240}
+        style={{
+          overflow: 'auto',
+          height: '100vh',
+          position: 'fixed',
+          left: 0,
+          top: 0,
+          bottom: 0,
+          background: themeToken.colorBgContainer,
+          borderRight: `1px solid ${themeToken.colorBorderSecondary}`,
+        }}
+      >
+        <div
+          style={{
+            height: 64,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            fontWeight: 700,
+            fontSize: sidebarCollapsed ? 14 : 16,
+            color: themeToken.colorPrimary,
+            borderBottom: `1px solid ${themeToken.colorBorderSecondary}`,
+            padding: '0 16px',
+            whiteSpace: 'nowrap',
+            overflow: 'hidden',
+          }}
+        >
+          {sidebarCollapsed ? '医养' : '智慧医养平台'}
+        </div>
+        <Menu
+          mode="inline"
+          selectedKeys={selectedKeys}
+          items={menuItems}
+          onClick={handleMenuClick}
+          style={{ border: 'none' }}
+        />
+      </Sider>
+      <Layout style={{ marginLeft: sidebarCollapsed ? 80 : 240, transition: 'margin-left 0.2s' }}>
+        <Header
+          style={{
+            padding: '0 24px',
+            background: themeToken.colorBgContainer,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            borderBottom: `1px solid ${themeToken.colorBorderSecondary}`,
+            position: 'sticky',
+            top: 0,
+            zIndex: 10,
+          }}
+        >
+          <Button
+            type="text"
+            icon={sidebarCollapsed ? <MenuUnfoldOutlined /> : <MenuFoldOutlined />}
+            onClick={toggleSidebar}
+          />
+          <Dropdown menu={{ items: userMenuItems }} placement="bottomRight">
+            <Button type="text" icon={<UserOutlined />}>
+              {user?.real_name || user?.username || '用户'}
+            </Button>
+          </Dropdown>
+        </Header>
+        <Content style={{ margin: 24, minHeight: 280 }}>
+          <Outlet />
+        </Content>
+      </Layout>
+    </Layout>
+  );
+};
+
+export default ElderLayout;

--- a/frontend/src/layouts/FamilyLayout.tsx
+++ b/frontend/src/layouts/FamilyLayout.tsx
@@ -1,0 +1,150 @@
+import React, { useMemo } from 'react';
+import { Outlet, useNavigate, useLocation } from 'react-router-dom';
+import { Layout, Menu, Button, Dropdown, theme } from 'antd';
+import {
+  HomeOutlined,
+  HeartOutlined,
+  UserOutlined,
+  LogoutOutlined,
+  MenuFoldOutlined,
+  MenuUnfoldOutlined,
+} from '@ant-design/icons';
+import type { MenuProps } from 'antd';
+import { useAuthStore } from '../store/auth';
+import { useAppStore } from '../store/app';
+
+const { Header, Sider, Content } = Layout;
+
+type MenuItem = Required<MenuProps>['items'][number];
+
+const FamilyLayout: React.FC = () => {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { user, logout } = useAuthStore();
+  const { sidebarCollapsed, toggleSidebar } = useAppStore();
+  const { token: themeToken } = theme.useToken();
+
+  const menuItems = useMemo<MenuItem[]>(() => [
+    {
+      key: '/family',
+      icon: <HomeOutlined />,
+      label: '首页',
+    },
+    {
+      key: '/family/elder',
+      icon: <HeartOutlined />,
+      label: '老人健康',
+    },
+    {
+      key: '/family/personal',
+      icon: <UserOutlined />,
+      label: '个人账户',
+    },
+  ], []);
+
+  const selectedKeys = useMemo(() => {
+    return [location.pathname];
+  }, [location.pathname]);
+
+  const handleMenuClick: MenuProps['onClick'] = ({ key }) => {
+    navigate(key);
+  };
+
+  const handleLogout = async () => {
+    await logout();
+    navigate('/login');
+  };
+
+  const userMenuItems: MenuProps['items'] = [
+    {
+      key: 'personal',
+      icon: <UserOutlined />,
+      label: '个人账户',
+      onClick: () => navigate('/family/personal'),
+    },
+    { type: 'divider' },
+    {
+      key: 'logout',
+      icon: <LogoutOutlined />,
+      label: '退出登录',
+      onClick: handleLogout,
+    },
+  ];
+
+  return (
+    <Layout style={{ minHeight: '100vh' }}>
+      <Sider
+        trigger={null}
+        collapsible
+        collapsed={sidebarCollapsed}
+        width={240}
+        style={{
+          overflow: 'auto',
+          height: '100vh',
+          position: 'fixed',
+          left: 0,
+          top: 0,
+          bottom: 0,
+          background: themeToken.colorBgContainer,
+          borderRight: `1px solid ${themeToken.colorBorderSecondary}`,
+        }}
+      >
+        <div
+          style={{
+            height: 64,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            fontWeight: 700,
+            fontSize: sidebarCollapsed ? 14 : 16,
+            color: themeToken.colorPrimary,
+            borderBottom: `1px solid ${themeToken.colorBorderSecondary}`,
+            padding: '0 16px',
+            whiteSpace: 'nowrap',
+            overflow: 'hidden',
+          }}
+        >
+          {sidebarCollapsed ? '医养' : '智慧医养平台'}
+        </div>
+        <Menu
+          mode="inline"
+          selectedKeys={selectedKeys}
+          items={menuItems}
+          onClick={handleMenuClick}
+          style={{ border: 'none' }}
+        />
+      </Sider>
+      <Layout style={{ marginLeft: sidebarCollapsed ? 80 : 240, transition: 'margin-left 0.2s' }}>
+        <Header
+          style={{
+            padding: '0 24px',
+            background: themeToken.colorBgContainer,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            borderBottom: `1px solid ${themeToken.colorBorderSecondary}`,
+            position: 'sticky',
+            top: 0,
+            zIndex: 10,
+          }}
+        >
+          <Button
+            type="text"
+            icon={sidebarCollapsed ? <MenuUnfoldOutlined /> : <MenuFoldOutlined />}
+            onClick={toggleSidebar}
+          />
+          <Dropdown menu={{ items: userMenuItems }} placement="bottomRight">
+            <Button type="text" icon={<UserOutlined />}>
+              {user?.real_name || user?.username || '用户'}
+            </Button>
+          </Dropdown>
+        </Header>
+        <Content style={{ margin: 24, minHeight: 280 }}>
+          <Outlet />
+        </Content>
+      </Layout>
+    </Layout>
+  );
+};
+
+export default FamilyLayout;

--- a/frontend/src/pages/doctors/DoctorPage.tsx
+++ b/frontend/src/pages/doctors/DoctorPage.tsx
@@ -1,0 +1,153 @@
+import React, { useState, useCallback } from 'react';
+import { Button, Tag, Space, Popconfirm, message } from 'antd';
+import { PlusOutlined, EditOutlined, DeleteOutlined } from '@ant-design/icons';
+import type { ColumnsType } from 'antd/es/table';
+import AppTable from '../../components/AppTable';
+import AppForm, { type FormFieldConfig } from '../../components/AppForm';
+import PermissionGuard from '../../components/PermissionGuard';
+import { useTable } from '../../hooks/useTable';
+import { getUsers, createUser, updateUser, deleteUser } from '../../api/users';
+import { formatDateTime } from '../../utils/formatter';
+import type { User } from '../../types/user';
+import type { PaginationParams } from '../../types/common';
+
+const createFields: FormFieldConfig[] = [
+  { name: 'username', label: '用户名', required: true },
+  { name: 'real_name', label: '姓名', required: true },
+  { name: 'phone', label: '手机号', required: true },
+  { name: 'email', label: '邮箱' },
+  { name: 'password', label: '密码', type: 'password', required: true },
+];
+
+const editFields: FormFieldConfig[] = [
+  { name: 'real_name', label: '姓名', required: true },
+  { name: 'phone', label: '手机号', required: true },
+  { name: 'email', label: '邮箱' },
+  {
+    name: 'status',
+    label: '状态',
+    type: 'select',
+    options: [
+      { label: '正常', value: 'active' },
+      { label: '禁用', value: 'disabled' },
+    ],
+  },
+];
+
+const DoctorPage: React.FC = () => {
+  const [formVisible, setFormVisible] = useState(false);
+  const [editingUser, setEditingUser] = useState<User | null>(null);
+
+  const fetchFn = useCallback(
+    (params: PaginationParams & { page: number; page_size: number }) =>
+      getUsers({ ...params, role: 'doctor' }),
+    [],
+  );
+
+  const { data, loading, pagination, handleTableChange, refresh, handleSearch } =
+    useTable<User, PaginationParams>(fetchFn);
+
+  const handleCreate = () => {
+    setEditingUser(null);
+    setFormVisible(true);
+  };
+
+  const handleEdit = (record: User) => {
+    setEditingUser(record);
+    setFormVisible(true);
+  };
+
+  const handleDelete = async (id: number) => {
+    try {
+      await deleteUser(id);
+      message.success('删除成功');
+      refresh();
+    } catch (err) {
+      message.error(err instanceof Error ? err.message : '删除失败');
+    }
+  };
+
+  const columns: ColumnsType<User> = [
+    { title: '用户名', dataIndex: 'username', width: 120 },
+    { title: '姓名', dataIndex: 'real_name', width: 100 },
+    { title: '手机号', dataIndex: 'phone', width: 130 },
+    { title: '邮箱', dataIndex: 'email', width: 180, ellipsis: true },
+    {
+      title: '状态',
+      dataIndex: 'status',
+      width: 80,
+      render: (status: string) => (
+        <Tag color={status === 'active' ? 'green' : 'red'}>
+          {status === 'active' ? '正常' : '禁用'}
+        </Tag>
+      ),
+    },
+    { title: '创建时间', dataIndex: 'created_at', render: formatDateTime, width: 170 },
+    {
+      title: '操作',
+      key: 'actions',
+      width: 160,
+      fixed: 'right',
+      render: (_, record) => (
+        <Space>
+          <PermissionGuard permission="user:manage">
+            <Button
+              type="link"
+              size="small"
+              icon={<EditOutlined />}
+              onClick={() => handleEdit(record)}
+            >
+              编辑
+            </Button>
+            <Popconfirm title="确定删除该医生？" onConfirm={() => handleDelete(record.id)}>
+              <Button type="link" size="small" danger icon={<DeleteOutlined />}>
+                删除
+              </Button>
+            </Popconfirm>
+          </PermissionGuard>
+        </Space>
+      ),
+    },
+  ];
+
+  return (
+    <>
+      <AppTable<User>
+        columns={columns}
+        dataSource={data}
+        loading={loading}
+        pagination={pagination}
+        onChange={handleTableChange}
+        onSearch={handleSearch}
+        searchPlaceholder="搜索用户名/姓名/手机号"
+        toolbar={
+          <PermissionGuard permission="user:manage">
+            <Button type="primary" icon={<PlusOutlined />} onClick={handleCreate}>
+              新增医生
+            </Button>
+          </PermissionGuard>
+        }
+      />
+
+      <AppForm
+        title={editingUser ? '编辑医生' : '新增医生'}
+        visible={formVisible}
+        fields={editingUser ? editFields : createFields}
+        initialValues={editingUser || undefined}
+        onSubmit={async (values) => {
+          if (editingUser) {
+            await updateUser(editingUser.id, values as Parameters<typeof updateUser>[1]);
+          } else {
+            await createUser({ ...values, role_ids: [2] } as Parameters<typeof createUser>[0]);
+          }
+          message.success(editingUser ? '更新成功' : '创建成功');
+          setFormVisible(false);
+          refresh();
+        }}
+        onCancel={() => setFormVisible(false)}
+      />
+    </>
+  );
+};
+
+export default DoctorPage;

--- a/frontend/src/pages/elder-portal/ElderHomePage.tsx
+++ b/frontend/src/pages/elder-portal/ElderHomePage.tsx
@@ -1,0 +1,163 @@
+import React, { useEffect, useState } from 'react';
+import { Card, Descriptions, Spin, Tag, Table, Typography, Alert } from 'antd';
+import type { ColumnsType } from 'antd/es/table';
+import { useAuthStore } from '../../store/auth';
+import { getElderSelf, getElderHealthRecords } from '../../api/elderPortal';
+
+const { Title } = Typography;
+
+interface ElderProfile {
+  id: number;
+  name: string;
+  gender: string;
+  birth_date: string;
+  phone: string;
+  address: string;
+  emergency_contact_name: string;
+  emergency_contact_phone: string;
+  tags: string[];
+}
+
+interface HealthRecord {
+  id: number;
+  record_date: string;
+  record_type: string;
+  summary: string;
+  created_at: string;
+}
+
+const ElderHomePage: React.FC = () => {
+  const user = useAuthStore((state) => state.user);
+  const [profile, setProfile] = useState<ElderProfile | null>(null);
+  const [healthRecords, setHealthRecords] = useState<HealthRecord[]>([]);
+  const [profileLoading, setProfileLoading] = useState(true);
+  const [recordsLoading, setRecordsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchProfile = async () => {
+      setProfileLoading(true);
+      try {
+        const res = await getElderSelf();
+        setProfile(res.data);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : '获取个人信息失败');
+      } finally {
+        setProfileLoading(false);
+      }
+    };
+    fetchProfile();
+  }, []);
+
+  useEffect(() => {
+    const elderId = user?.elder_id;
+    if (!elderId) return;
+
+    const fetchRecords = async () => {
+      setRecordsLoading(true);
+      try {
+        const res = await getElderHealthRecords(elderId, { page: 1, page_size: 5 });
+        setHealthRecords(res.data?.items || []);
+      } catch {
+        // Silently handle — profile section is more important
+      } finally {
+        setRecordsLoading(false);
+      }
+    };
+    fetchRecords();
+  }, [user?.elder_id]);
+
+  const genderMap: Record<string, string> = {
+    male: '男',
+    female: '女',
+    M: '男',
+    F: '女',
+  };
+
+  const columns: ColumnsType<HealthRecord> = [
+    {
+      title: '记录日期',
+      dataIndex: 'record_date',
+      key: 'record_date',
+      width: 120,
+    },
+    {
+      title: '类型',
+      dataIndex: 'record_type',
+      key: 'record_type',
+      width: 100,
+    },
+    {
+      title: '摘要',
+      dataIndex: 'summary',
+      key: 'summary',
+      ellipsis: true,
+    },
+    {
+      title: '创建时间',
+      dataIndex: 'created_at',
+      key: 'created_at',
+      width: 180,
+    },
+  ];
+
+  if (profileLoading) {
+    return (
+      <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '50vh' }}>
+        <Spin size="large" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return <Alert type="error" message="加载失败" description={error} showIcon />;
+  }
+
+  return (
+    <div>
+      <Card style={{ marginBottom: 16 }}>
+        <Title level={4} style={{ marginBottom: 16 }}>
+          {profile?.name ? `${profile.name}，您好！` : '您好！'}
+        </Title>
+        <Descriptions column={{ xs: 1, sm: 2 }} bordered>
+          <Descriptions.Item label="姓名">{profile?.name || '-'}</Descriptions.Item>
+          <Descriptions.Item label="性别">
+            {profile?.gender ? (genderMap[profile.gender] || profile.gender) : '-'}
+          </Descriptions.Item>
+          <Descriptions.Item label="出生日期">{profile?.birth_date || '-'}</Descriptions.Item>
+          <Descriptions.Item label="联系电话">{profile?.phone || '-'}</Descriptions.Item>
+          <Descriptions.Item label="住址" span={2}>{profile?.address || '-'}</Descriptions.Item>
+          <Descriptions.Item label="紧急联系人">
+            {profile?.emergency_contact_name || '-'}
+          </Descriptions.Item>
+          <Descriptions.Item label="紧急联系电话">
+            {profile?.emergency_contact_phone || '-'}
+          </Descriptions.Item>
+          {profile?.tags && profile.tags.length > 0 && (
+            <Descriptions.Item label="标签" span={2}>
+              {profile.tags.map((tag) => (
+                <Tag color="blue" key={tag}>
+                  {tag}
+                </Tag>
+              ))}
+            </Descriptions.Item>
+          )}
+        </Descriptions>
+      </Card>
+
+      <Card title="近期健康记录">
+        <Table<HealthRecord>
+          columns={columns}
+          dataSource={healthRecords}
+          loading={recordsLoading}
+          rowKey="id"
+          pagination={false}
+          locale={{ emptyText: '暂无健康记录' }}
+          scroll={{ x: 'max-content' }}
+        />
+      </Card>
+    </div>
+  );
+};
+
+export default ElderHomePage;

--- a/frontend/src/pages/elder-portal/ElderInvitePage.tsx
+++ b/frontend/src/pages/elder-portal/ElderInvitePage.tsx
@@ -1,0 +1,248 @@
+import React, { useEffect, useState, useCallback } from 'react';
+import {
+  Card,
+  Button,
+  Typography,
+  Table,
+  Space,
+  Spin,
+  Alert,
+  Empty,
+  Modal,
+  message,
+  Tag,
+} from 'antd';
+import {
+  CopyOutlined,
+  PlusOutlined,
+  DeleteOutlined,
+  ExclamationCircleOutlined,
+} from '@ant-design/icons';
+import type { ColumnsType } from 'antd/es/table';
+import { useAuthStore } from '../../store/auth';
+import {
+  getInviteCode,
+  generateInviteCode,
+  revokeInviteCode,
+  getElderFamily,
+} from '../../api/elderPortal';
+
+const { Title, Text, Paragraph } = Typography;
+
+interface InviteCode {
+  code: string;
+  expires_at: string;
+  used_count: number;
+  max_uses: number;
+}
+
+interface FamilyMember {
+  id: number;
+  real_name: string;
+  relationship: string;
+  created_at: string;
+}
+
+const MAX_FAMILY_MEMBERS = 3;
+
+const ElderInvitePage: React.FC = () => {
+  const user = useAuthStore((state) => state.user);
+  const elderId = user?.elder_id;
+
+  const [inviteCode, setInviteCode] = useState<InviteCode | null>(null);
+  const [familyMembers, setFamilyMembers] = useState<FamilyMember[]>([]);
+  const [codeLoading, setCodeLoading] = useState(true);
+  const [familyLoading, setFamilyLoading] = useState(true);
+  const [actionLoading, setActionLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchInviteCode = useCallback(async () => {
+    if (!elderId) return;
+    setCodeLoading(true);
+    try {
+      const res = await getInviteCode(elderId);
+      setInviteCode(res.data || null);
+    } catch {
+      setInviteCode(null);
+    } finally {
+      setCodeLoading(false);
+    }
+  }, [elderId]);
+
+  const fetchFamily = useCallback(async () => {
+    setFamilyLoading(true);
+    try {
+      const res = await getElderFamily();
+      setFamilyMembers(res.data || []);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : '获取家属列表失败');
+    } finally {
+      setFamilyLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchInviteCode();
+    fetchFamily();
+  }, [fetchInviteCode, fetchFamily]);
+
+  const handleGenerate = async () => {
+    if (!elderId) return;
+    setActionLoading(true);
+    try {
+      await generateInviteCode(elderId);
+      message.success('邀请码已生成');
+      await fetchInviteCode();
+    } catch (err) {
+      message.error(err instanceof Error ? err.message : '生成邀请码失败');
+    } finally {
+      setActionLoading(false);
+    }
+  };
+
+  const handleRevoke = () => {
+    if (!elderId) return;
+    Modal.confirm({
+      title: '确认撤销',
+      icon: <ExclamationCircleOutlined />,
+      content: '撤销后，当前邀请码将立即失效，已绑定的家属不受影响。',
+      okText: '确认撤销',
+      cancelText: '取消',
+      okButtonProps: { danger: true },
+      onOk: async () => {
+        setActionLoading(true);
+        try {
+          await revokeInviteCode(elderId);
+          message.success('邀请码已撤销');
+          setInviteCode(null);
+        } catch (err) {
+          message.error(err instanceof Error ? err.message : '撤销邀请码失败');
+        } finally {
+          setActionLoading(false);
+        }
+      },
+    });
+  };
+
+  const handleCopyLink = () => {
+    if (!inviteCode) return;
+    const link = `${window.location.origin}/register/family?code=${inviteCode.code}`;
+    navigator.clipboard.writeText(link).then(() => {
+      message.success('邀请链接已复制到剪贴板');
+    }).catch(() => {
+      message.error('复制失败，请手动复制');
+    });
+  };
+
+  const familyColumns: ColumnsType<FamilyMember> = [
+    {
+      title: '姓名',
+      dataIndex: 'real_name',
+      key: 'real_name',
+    },
+    {
+      title: '关系',
+      dataIndex: 'relationship',
+      key: 'relationship',
+    },
+    {
+      title: '绑定时间',
+      dataIndex: 'created_at',
+      key: 'created_at',
+      width: 180,
+    },
+  ];
+
+  if (!elderId) {
+    return <Alert type="warning" message="账户异常" description="未找到关联的老人信息，请联系管理员。" showIcon />;
+  }
+
+  return (
+    <div>
+      <Card style={{ marginBottom: 16 }}>
+        <Title level={4} style={{ marginTop: 0 }}>邀请家属</Title>
+        <Paragraph type="secondary">
+          生成邀请码分享给家属，家属可通过邀请码注册并绑定账号。每位老人最多绑定 {MAX_FAMILY_MEMBERS} 位家属。
+        </Paragraph>
+
+        {codeLoading ? (
+          <div style={{ textAlign: 'center', padding: 24 }}>
+            <Spin />
+          </div>
+        ) : inviteCode ? (
+          <Card
+            type="inner"
+            style={{ marginBottom: 16, background: '#fafafa' }}
+          >
+            <Space direction="vertical" size="middle" style={{ width: '100%' }}>
+              <div>
+                <Text type="secondary">当前邀请码</Text>
+                <div style={{ marginTop: 8 }}>
+                  <Text
+                    copyable
+                    style={{ fontSize: 28, fontWeight: 700, letterSpacing: 2 }}
+                  >
+                    {inviteCode.code}
+                  </Text>
+                </div>
+              </div>
+              <Space split={<span style={{ color: '#d9d9d9' }}>|</span>}>
+                <Text type="secondary">
+                  过期时间：{inviteCode.expires_at}
+                </Text>
+                <Tag color={inviteCode.used_count >= inviteCode.max_uses ? 'red' : 'blue'}>
+                  已使用 {inviteCode.used_count}/{inviteCode.max_uses}
+                </Tag>
+              </Space>
+              <Space>
+                <Button
+                  icon={<CopyOutlined />}
+                  onClick={handleCopyLink}
+                >
+                  复制邀请链接
+                </Button>
+                <Button
+                  danger
+                  icon={<DeleteOutlined />}
+                  loading={actionLoading}
+                  onClick={handleRevoke}
+                >
+                  撤销邀请码
+                </Button>
+              </Space>
+            </Space>
+          </Card>
+        ) : (
+          <div style={{ textAlign: 'center', padding: 24 }}>
+            <Empty description="暂无有效邀请码" style={{ marginBottom: 16 }} />
+            <Button
+              type="primary"
+              icon={<PlusOutlined />}
+              loading={actionLoading}
+              onClick={handleGenerate}
+            >
+              生成邀请码
+            </Button>
+          </div>
+        )}
+      </Card>
+
+      <Card title="已绑定家属">
+        <Table<FamilyMember>
+          columns={familyColumns}
+          dataSource={familyMembers}
+          loading={familyLoading}
+          rowKey="id"
+          pagination={false}
+          locale={{ emptyText: '暂无绑定家属' }}
+          scroll={{ x: 'max-content' }}
+        />
+        {error && (
+          <Alert type="error" message={error} style={{ marginTop: 16 }} showIcon />
+        )}
+      </Card>
+    </div>
+  );
+};
+
+export default ElderInvitePage;

--- a/frontend/src/pages/elders/ElderArchiveListPage.tsx
+++ b/frontend/src/pages/elders/ElderArchiveListPage.tsx
@@ -1,0 +1,70 @@
+import React, { useCallback } from 'react';
+import { Card, Row, Col, Tag, Input, Spin, Empty } from 'antd';
+import { useNavigate } from 'react-router-dom';
+import { useTable } from '../../hooks/useTable';
+import { getElders } from '../../api/elders';
+import { formatGender } from '../../utils/formatter';
+import type { Elder, ElderListQuery } from '../../types/elder';
+
+const { Search } = Input;
+
+const ElderArchiveListPage: React.FC = () => {
+  const navigate = useNavigate();
+
+  const fetchFn = useCallback(
+    (params: ElderListQuery & { page: number; page_size: number }) => getElders(params),
+    [],
+  );
+
+  const { data, loading, handleSearch } = useTable<Elder, ElderListQuery>(fetchFn);
+
+  return (
+    <div>
+      <div style={{ marginBottom: 16, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+        <h2 style={{ margin: 0 }}>老人健康档案</h2>
+        <Search
+          placeholder="搜索姓名/手机号/身份证"
+          allowClear
+          onSearch={handleSearch}
+          style={{ width: 300 }}
+        />
+      </div>
+
+      {loading ? (
+        <div style={{ textAlign: 'center', padding: 100 }}>
+          <Spin size="large" />
+        </div>
+      ) : data.length === 0 ? (
+        <Empty description="暂无老人档案" />
+      ) : (
+        <Row gutter={[16, 16]}>
+          {data.map((elder) => (
+            <Col key={elder.id} xs={24} sm={12} md={8} lg={6}>
+              <Card
+                hoverable
+                onClick={() => navigate(`/elders/${elder.id}/archive`)}
+                style={{ borderRadius: 8 }}
+              >
+                <Card.Meta
+                  title={elder.name}
+                  description={
+                    <div>
+                      <div style={{ marginBottom: 4 }}>{formatGender(elder.gender)} | {elder.phone || '-'}</div>
+                      <div>
+                        {elder.tags?.map((tag) => (
+                          <Tag key={tag} color="blue" style={{ marginBottom: 4 }}>{tag}</Tag>
+                        ))}
+                      </div>
+                    </div>
+                  }
+                />
+              </Card>
+            </Col>
+          ))}
+        </Row>
+      )}
+    </div>
+  );
+};
+
+export default ElderArchiveListPage;

--- a/frontend/src/pages/elders/ElderListPage.tsx
+++ b/frontend/src/pages/elders/ElderListPage.tsx
@@ -7,7 +7,7 @@ import AppTable from '../../components/AppTable';
 import AppForm, { type FormFieldConfig } from '../../components/AppForm';
 import PermissionGuard from '../../components/PermissionGuard';
 import { useTable } from '../../hooks/useTable';
-import { getElders, createElder, updateElder, deleteElder } from '../../api/elders';
+import { getElders, createElder, updateElder, deleteElder, resetElderPassword, updateElderAccountStatus, activateElderAccount } from '../../api/elders';
 import { formatGender, formatDate } from '../../utils/formatter';
 import { GENDER_OPTIONS, RISK_LEVEL_OPTIONS, ACCOUNT_STATUS_OPTIONS } from '../../utils/constants';
 import type { Elder, ElderListQuery } from '../../types/elder';
@@ -57,6 +57,36 @@ const ElderListPage: React.FC = () => {
     }
   };
 
+  const handleActivateAccount = async (record: Elder) => {
+    try {
+      const res = await activateElderAccount(record.id);
+      message.success(`账户已激活，用户名: ${res.data.username}，密码: ${res.data.password}`);
+      refresh();
+    } catch (err) {
+      message.error(err instanceof Error ? err.message : '激活失败');
+    }
+  };
+
+  const handleResetPassword = async (id: number) => {
+    try {
+      await resetElderPassword(id);
+      message.success('密码已重置');
+    } catch (err) {
+      message.error(err instanceof Error ? err.message : '重置失败');
+    }
+  };
+
+  const handleToggleStatus = async (id: number, currentStatus: string) => {
+    const newStatus = currentStatus === 'active' ? 'disabled' : 'active';
+    try {
+      await updateElderAccountStatus(id, newStatus);
+      message.success(newStatus === 'active' ? '已启用' : '已禁用');
+      refresh();
+    } catch (err) {
+      message.error(err instanceof Error ? err.message : '操作失败');
+    }
+  };
+
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const handleSubmit = async (values: any) => {
     setSubmitLoading(true);
@@ -91,6 +121,18 @@ const ElderListPage: React.FC = () => {
         tags?.map((tag) => <Tag key={tag} color="blue">{tag}</Tag>),
     },
     {
+      title: '账户名',
+      dataIndex: 'username',
+      width: 130,
+      render: (val: string | undefined) => val || <Tag>未激活</Tag>,
+    },
+    {
+      title: '家属数',
+      dataIndex: 'family_count',
+      width: 80,
+      render: (val: number | undefined) => val ?? 0,
+    },
+    {
       title: '账户状态',
       dataIndex: 'account_status',
       width: 100,
@@ -103,7 +145,7 @@ const ElderListPage: React.FC = () => {
     {
       title: '操作',
       key: 'actions',
-      width: 200,
+      width: 360,
       fixed: 'right',
       render: (_, record) => (
         <Space>
@@ -124,6 +166,31 @@ const ElderListPage: React.FC = () => {
             >
               编辑
             </Button>
+          </PermissionGuard>
+          <PermissionGuard permission="elder:update">
+            {!record.username ? (
+              <Popconfirm title="确定为该老人激活登录账户？" onConfirm={() => handleActivateAccount(record)}>
+                <Button type="link" size="small">激活账户</Button>
+              </Popconfirm>
+            ) : (
+              <>
+                <Popconfirm title="确定重置密码？" onConfirm={() => handleResetPassword(record.id)}>
+                  <Button type="link" size="small">重置密码</Button>
+                </Popconfirm>
+                <Popconfirm
+                  title={`确定${record.account_status === 'active' ? '禁用' : '启用'}该账户？`}
+                  onConfirm={() => handleToggleStatus(record.id, record.account_status)}
+                >
+                  <Button
+                    type="link"
+                    size="small"
+                    danger={record.account_status === 'active'}
+                  >
+                    {record.account_status === 'active' ? '禁用' : '启用'}
+                  </Button>
+                </Popconfirm>
+              </>
+            )}
           </PermissionGuard>
           <PermissionGuard permission="elder:delete">
             <Popconfirm title="确定删除该老人档案？" onConfirm={() => handleDelete(record.id)}>

--- a/frontend/src/pages/family-portal/FamilyElderHealthPage.tsx
+++ b/frontend/src/pages/family-portal/FamilyElderHealthPage.tsx
@@ -1,0 +1,325 @@
+import React, { useEffect, useState, useCallback } from 'react';
+import { Card, Tabs, Table, Spin, Empty, Descriptions, Tag, Typography } from 'antd';
+import { HeartOutlined, AlertOutlined } from '@ant-design/icons';
+import type { ColumnsType } from 'antd/es/table';
+import { getFamilySelf, getFamilyElder, getElderHealthRecords, getElderAlerts } from '../../api/family';
+import type { FamilyMemberInfo, FamilyElderInfo } from '../../types/family';
+
+const { Text } = Typography;
+
+interface HealthRecord {
+  id: number;
+  record_date: string;
+  systolic_bp?: number;
+  diastolic_bp?: number;
+  blood_glucose?: number;
+  heart_rate?: number;
+  temperature?: number;
+  notes?: string;
+  created_at: string;
+}
+
+interface AlertRecord {
+  id: number;
+  elder_name: string;
+  alert_type: string;
+  level: string;
+  message: string;
+  status: string;
+  created_at: string;
+}
+
+const alertLevelColorMap: Record<string, string> = {
+  high: 'red',
+  medium: 'orange',
+  low: 'blue',
+};
+
+const alertStatusLabelMap: Record<string, string> = {
+  pending: '待处理',
+  processing: '处理中',
+  resolved: '已解决',
+  closed: '已关闭',
+};
+
+const healthColumns: ColumnsType<HealthRecord> = [
+  {
+    title: '记录日期',
+    dataIndex: 'record_date',
+    key: 'record_date',
+    width: 120,
+  },
+  {
+    title: '收缩压 (mmHg)',
+    dataIndex: 'systolic_bp',
+    key: 'systolic_bp',
+    width: 130,
+    render: (val?: number) => val ?? '-',
+  },
+  {
+    title: '舒张压 (mmHg)',
+    dataIndex: 'diastolic_bp',
+    key: 'diastolic_bp',
+    width: 130,
+    render: (val?: number) => val ?? '-',
+  },
+  {
+    title: '血糖 (mmol/L)',
+    dataIndex: 'blood_glucose',
+    key: 'blood_glucose',
+    width: 130,
+    render: (val?: number) => val ?? '-',
+  },
+  {
+    title: '心率 (bpm)',
+    dataIndex: 'heart_rate',
+    key: 'heart_rate',
+    width: 110,
+    render: (val?: number) => val ?? '-',
+  },
+  {
+    title: '体温 (*C)',
+    dataIndex: 'temperature',
+    key: 'temperature',
+    width: 100,
+    render: (val?: number) => val ?? '-',
+  },
+  {
+    title: '备注',
+    dataIndex: 'notes',
+    key: 'notes',
+    ellipsis: true,
+    render: (val?: string) => val || '-',
+  },
+];
+
+const alertColumns: ColumnsType<AlertRecord> = [
+  {
+    title: '预警类型',
+    dataIndex: 'alert_type',
+    key: 'alert_type',
+    width: 120,
+  },
+  {
+    title: '级别',
+    dataIndex: 'level',
+    key: 'level',
+    width: 80,
+    render: (level: string) => (
+      <Tag color={alertLevelColorMap[level] || 'default'}>{level}</Tag>
+    ),
+  },
+  {
+    title: '内容',
+    dataIndex: 'message',
+    key: 'message',
+    ellipsis: true,
+  },
+  {
+    title: '状态',
+    dataIndex: 'status',
+    key: 'status',
+    width: 100,
+    render: (status: string) => alertStatusLabelMap[status] || status,
+  },
+  {
+    title: '时间',
+    dataIndex: 'created_at',
+    key: 'created_at',
+    width: 180,
+  },
+];
+
+const FamilyElderHealthPage: React.FC = () => {
+  const [familyInfo, setFamilyInfo] = useState<FamilyMemberInfo | null>(null);
+  const [elderInfo, setElderInfo] = useState<FamilyElderInfo | null>(null);
+  const [healthRecords, setHealthRecords] = useState<HealthRecord[]>([]);
+  const [alerts, setAlerts] = useState<AlertRecord[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [healthLoading, setHealthLoading] = useState(false);
+  const [alertsLoading, setAlertsLoading] = useState(false);
+  const [healthTotal, setHealthTotal] = useState(0);
+  const [alertsTotal, setAlertsTotal] = useState(0);
+  const [healthPage, setHealthPage] = useState(1);
+  const [alertsPage, setAlertsPage] = useState(1);
+  const pageSize = 10;
+
+  useEffect(() => {
+    const fetchBaseData = async () => {
+      setLoading(true);
+      try {
+        const [selfRes, elderRes] = await Promise.all([
+          getFamilySelf(),
+          getFamilyElder(),
+        ]);
+        setFamilyInfo(selfRes.data as FamilyMemberInfo);
+        setElderInfo(elderRes.data as FamilyElderInfo);
+      } catch {
+        // Error handled by http interceptor
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchBaseData();
+  }, []);
+
+  const fetchHealthRecords = useCallback(async (page: number) => {
+    if (!familyInfo) return;
+    setHealthLoading(true);
+    try {
+      const res = await getElderHealthRecords(familyInfo.elder_id, {
+        page,
+        page_size: pageSize,
+      });
+      const data = res.data as { items: HealthRecord[]; total: number };
+      setHealthRecords(data.items || []);
+      setHealthTotal(data.total || 0);
+    } catch {
+      // Error handled by http interceptor
+    } finally {
+      setHealthLoading(false);
+    }
+  }, [familyInfo]);
+
+  const fetchAlerts = useCallback(async (page: number) => {
+    if (!familyInfo) return;
+    setAlertsLoading(true);
+    try {
+      const res = await getElderAlerts({
+        elder_id: familyInfo.elder_id,
+        page,
+        page_size: pageSize,
+      });
+      const data = res.data as { items: AlertRecord[]; total: number };
+      setAlerts(data.items || []);
+      setAlertsTotal(data.total || 0);
+    } catch {
+      // Error handled by http interceptor
+    } finally {
+      setAlertsLoading(false);
+    }
+  }, [familyInfo]);
+
+  // Fetch health records when familyInfo is ready or page changes
+  useEffect(() => {
+    if (familyInfo) {
+      fetchHealthRecords(healthPage);
+    }
+  }, [familyInfo, healthPage, fetchHealthRecords]);
+
+  // Fetch alerts when familyInfo is ready or page changes
+  useEffect(() => {
+    if (familyInfo) {
+      fetchAlerts(alertsPage);
+    }
+  }, [familyInfo, alertsPage, fetchAlerts]);
+
+  if (loading) {
+    return (
+      <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '50vh' }}>
+        <Spin size="large" />
+      </div>
+    );
+  }
+
+  const tabItems = [
+    {
+      key: 'health',
+      label: (
+        <span>
+          <HeartOutlined style={{ marginRight: 4 }} />
+          健康记录
+        </span>
+      ),
+      children: (
+        <Spin spinning={healthLoading}>
+          {healthRecords.length === 0 && !healthLoading ? (
+            <Empty description="暂无健康记录" />
+          ) : (
+            <Table<HealthRecord>
+              columns={healthColumns}
+              dataSource={healthRecords}
+              rowKey="id"
+              pagination={{
+                current: healthPage,
+                pageSize,
+                total: healthTotal,
+                onChange: (page) => setHealthPage(page),
+                showTotal: (total) => `共 ${total} 条`,
+              }}
+              scroll={{ x: 800 }}
+            />
+          )}
+        </Spin>
+      ),
+    },
+    {
+      key: 'alerts',
+      label: (
+        <span>
+          <AlertOutlined style={{ marginRight: 4 }} />
+          风险预警
+        </span>
+      ),
+      children: (
+        <Spin spinning={alertsLoading}>
+          {alerts.length === 0 && !alertsLoading ? (
+            <Empty description="暂无风险预警" />
+          ) : (
+            <Table<AlertRecord>
+              columns={alertColumns}
+              dataSource={alerts}
+              rowKey="id"
+              pagination={{
+                current: alertsPage,
+                pageSize,
+                total: alertsTotal,
+                onChange: (page) => setAlertsPage(page),
+                showTotal: (total) => `共 ${total} 条`,
+              }}
+              scroll={{ x: 700 }}
+            />
+          )}
+        </Spin>
+      ),
+    },
+  ];
+
+  return (
+    <div>
+      {/* Elder info header */}
+      {elderInfo && (
+        <Card style={{ marginBottom: 24 }}>
+          <Descriptions
+            title={
+              <span>
+                <HeartOutlined style={{ marginRight: 8, color: '#ff4d4f' }} />
+                {elderInfo.name} 的健康信息
+              </span>
+            }
+            column={{ xs: 1, sm: 3 }}
+          >
+            <Descriptions.Item label="性别">{elderInfo.gender}</Descriptions.Item>
+            <Descriptions.Item label="联系电话">{elderInfo.phone}</Descriptions.Item>
+            <Descriptions.Item label="住址">{elderInfo.address}</Descriptions.Item>
+          </Descriptions>
+          {elderInfo.tags.length > 0 && (
+            <div style={{ marginTop: 8 }}>
+              <Text strong style={{ marginRight: 8 }}>标签：</Text>
+              {elderInfo.tags.map((tag) => (
+                <Tag key={tag} color="blue">{tag}</Tag>
+              ))}
+            </div>
+          )}
+        </Card>
+      )}
+
+      {/* Tabbed health data */}
+      <Card>
+        <Tabs items={tabItems} />
+      </Card>
+    </div>
+  );
+};
+
+export default FamilyElderHealthPage;

--- a/frontend/src/pages/family-portal/FamilyHomePage.tsx
+++ b/frontend/src/pages/family-portal/FamilyHomePage.tsx
@@ -1,0 +1,114 @@
+import React, { useEffect, useState } from 'react';
+import { Card, Spin, Tag, Button, Descriptions, Typography } from 'antd';
+import { HeartOutlined, PhoneOutlined, HomeOutlined } from '@ant-design/icons';
+import { useNavigate } from 'react-router-dom';
+import { getFamilySelf, getFamilyElder } from '../../api/family';
+import type { FamilyMemberInfo, FamilyElderInfo } from '../../types/family';
+
+const { Title, Text } = Typography;
+
+const FamilyHomePage: React.FC = () => {
+  const navigate = useNavigate();
+  const [familyInfo, setFamilyInfo] = useState<FamilyMemberInfo | null>(null);
+  const [elderInfo, setElderInfo] = useState<FamilyElderInfo | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      setLoading(true);
+      try {
+        const [selfRes, elderRes] = await Promise.all([
+          getFamilySelf(),
+          getFamilyElder(),
+        ]);
+        setFamilyInfo(selfRes.data as FamilyMemberInfo);
+        setElderInfo(elderRes.data as FamilyElderInfo);
+      } catch {
+        // Error is handled by the http interceptor
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchData();
+  }, []);
+
+  if (loading) {
+    return (
+      <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '50vh' }}>
+        <Spin size="large" />
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ maxWidth: 900, margin: '0 auto' }}>
+      {/* Welcome card */}
+      <Card style={{ marginBottom: 24 }}>
+        <Title level={4} style={{ margin: 0 }}>
+          您好，{familyInfo?.real_name}
+        </Title>
+        <Text type="secondary" style={{ marginTop: 4, display: 'block' }}>
+          关系：{familyInfo?.relationship} | 关联老人：{familyInfo?.elder_name}
+        </Text>
+      </Card>
+
+      {/* Elder info card */}
+      {elderInfo && (
+        <Card
+          title={
+            <span>
+              <HeartOutlined style={{ marginRight: 8, color: '#ff4d4f' }} />
+              老人基本信息
+            </span>
+          }
+          style={{ marginBottom: 24 }}
+        >
+          <Descriptions column={{ xs: 1, sm: 2 }} labelStyle={{ fontWeight: 500 }}>
+            <Descriptions.Item label="姓名">{elderInfo.name}</Descriptions.Item>
+            <Descriptions.Item label="性别">{elderInfo.gender}</Descriptions.Item>
+            {elderInfo.birth_date && (
+              <Descriptions.Item label="出生日期">{elderInfo.birth_date}</Descriptions.Item>
+            )}
+            <Descriptions.Item label="联系电话">
+              <PhoneOutlined style={{ marginRight: 4 }} />
+              {elderInfo.phone}
+            </Descriptions.Item>
+            <Descriptions.Item label="住址" span={2}>
+              <HomeOutlined style={{ marginRight: 4 }} />
+              {elderInfo.address}
+            </Descriptions.Item>
+            <Descriptions.Item label="紧急联系人">
+              {elderInfo.emergency_contact_name}
+            </Descriptions.Item>
+            <Descriptions.Item label="紧急联系电话">
+              {elderInfo.emergency_contact_phone}
+            </Descriptions.Item>
+          </Descriptions>
+
+          {elderInfo.tags.length > 0 && (
+            <div style={{ marginTop: 16 }}>
+              <Text strong style={{ marginRight: 8 }}>标签：</Text>
+              {elderInfo.tags.map((tag) => (
+                <Tag key={tag} color="blue">{tag}</Tag>
+              ))}
+            </div>
+          )}
+        </Card>
+      )}
+
+      {/* Quick links */}
+      <Card>
+        <Button
+          type="primary"
+          icon={<HeartOutlined />}
+          size="large"
+          onClick={() => navigate('/family/elder')}
+        >
+          查看老人健康记录
+        </Button>
+      </Card>
+    </div>
+  );
+};
+
+export default FamilyHomePage;

--- a/frontend/src/pages/family/FamilyMemberPage.tsx
+++ b/frontend/src/pages/family/FamilyMemberPage.tsx
@@ -1,0 +1,41 @@
+import React, { useCallback } from 'react';
+import type { ColumnsType } from 'antd/es/table';
+import AppTable from '../../components/AppTable';
+import { useTable } from '../../hooks/useTable';
+import { getFamilyMembers } from '../../api/family';
+import { formatDateTime } from '../../utils/formatter';
+import type { FamilyMemberAdmin } from '../../types/family';
+import type { PaginationParams } from '../../types/common';
+
+const FamilyMemberPage: React.FC = () => {
+  const fetchFn = useCallback(
+    (params: PaginationParams & { page: number; page_size: number }) => getFamilyMembers(params),
+    [],
+  );
+
+  const { data, loading, pagination, handleTableChange, handleSearch } =
+    useTable<FamilyMemberAdmin, PaginationParams>(fetchFn);
+
+  const columns: ColumnsType<FamilyMemberAdmin> = [
+    { title: '用户名', dataIndex: 'username', width: 130 },
+    { title: '姓名', dataIndex: 'real_name', width: 100 },
+    { title: '手机号', dataIndex: 'phone', width: 130 },
+    { title: '关联老人', dataIndex: 'elder_name', width: 120 },
+    { title: '关系', dataIndex: 'relationship', width: 100 },
+    { title: '注册时间', dataIndex: 'created_at', render: formatDateTime, width: 170 },
+  ];
+
+  return (
+    <AppTable<FamilyMemberAdmin>
+      columns={columns}
+      dataSource={data}
+      loading={loading}
+      pagination={pagination}
+      onChange={handleTableChange}
+      onSearch={handleSearch}
+      searchPlaceholder="搜索用户名/姓名/手机号"
+    />
+  );
+};
+
+export default FamilyMemberPage;

--- a/frontend/src/pages/family/FamilyRegisterPage.tsx
+++ b/frontend/src/pages/family/FamilyRegisterPage.tsx
@@ -1,0 +1,258 @@
+import React, { useState, useMemo, useEffect, useCallback } from 'react';
+import { Form, Input, Button, Card, Select, message } from 'antd';
+import {
+  KeyOutlined,
+  UserOutlined,
+  PhoneOutlined,
+  LockOutlined,
+  TeamOutlined,
+} from '@ant-design/icons';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import SlideCaptcha from '../../components/SlideCaptcha';
+import { validateInviteCode, registerFamily } from '../../api/family';
+import type { InviteCodeValidation } from '../../types/family';
+
+interface RegisterFormValues {
+  invite_code: string;
+  real_name: string;
+  phone: string;
+  password: string;
+  confirm_password: string;
+  relationship: string;
+}
+
+const relationshipOptions = [
+  { value: '子女', label: '子女' },
+  { value: '配偶', label: '配偶' },
+  { value: '兄弟姐妹', label: '兄弟姐妹' },
+  { value: '其他', label: '其他' },
+];
+
+const FamilyRegisterPage: React.FC = () => {
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const [form] = Form.useForm<RegisterFormValues>();
+  const [loading, setLoading] = useState(false);
+  const [captchaVisible, setCaptchaVisible] = useState(false);
+  const [codeValidation, setCodeValidation] = useState<InviteCodeValidation | null>(null);
+  const [validating, setValidating] = useState(false);
+
+  const sessionId = useMemo(() => crypto.randomUUID(), []);
+
+  const doValidateCode = useCallback(async (code: string) => {
+    if (!code || code.trim().length === 0) {
+      setCodeValidation(null);
+      return;
+    }
+    setValidating(true);
+    try {
+      const res = await validateInviteCode(code.trim());
+      setCodeValidation(res.data as InviteCodeValidation);
+    } catch {
+      setCodeValidation({ valid: false, elder_name: '', remaining_slots: 0 });
+    } finally {
+      setValidating(false);
+    }
+  }, []);
+
+  // Auto-fill and validate from URL query parameter
+  useEffect(() => {
+    const code = searchParams.get('code');
+    if (code) {
+      form.setFieldsValue({ invite_code: code });
+      doValidateCode(code);
+    }
+  }, [searchParams, form, doValidateCode]);
+
+  const handleCodeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    if (value.length >= 8) {
+      doValidateCode(value);
+    } else {
+      setCodeValidation(null);
+    }
+  };
+
+  const handleCodeBlur = () => {
+    const code = form.getFieldValue('invite_code') as string;
+    if (code && code.trim().length > 0) {
+      doValidateCode(code);
+    }
+  };
+
+  const handleSubmit = () => {
+    form.validateFields().then(() => {
+      setCaptchaVisible(true);
+    });
+  };
+
+  const handleCaptchaSuccess = async (captchaToken: string) => {
+    setCaptchaVisible(false);
+    const values = form.getFieldsValue();
+    setLoading(true);
+    try {
+      await registerFamily({
+        invite_code: values.invite_code,
+        real_name: values.real_name,
+        phone: values.phone,
+        password: values.password,
+        relationship: values.relationship,
+        captcha_token: captchaToken,
+        session_id: sessionId,
+      });
+      message.success('注册成功，请登录');
+      navigate('/login', { replace: true });
+    } catch (err) {
+      message.error(err instanceof Error ? err.message : '注册失败');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleCaptchaCancel = () => {
+    setCaptchaVisible(false);
+  };
+
+  return (
+    <>
+      <Card
+        style={{
+          width: 480,
+          borderRadius: 12,
+          boxShadow: '0 8px 32px rgba(0, 0, 0, 0.15)',
+        }}
+        styles={{ body: { padding: '40px 32px' } }}
+      >
+        <div style={{ textAlign: 'center', marginBottom: 32 }}>
+          <h1
+            style={{
+              fontSize: 22,
+              fontWeight: 700,
+              color: '#1677ff',
+              margin: 0,
+              lineHeight: 1.4,
+            }}
+          >
+            家属注册
+          </h1>
+          <p style={{ color: '#8c8c8c', fontSize: 14, margin: '8px 0 0' }}>
+            智慧医养大数据公共服务平台
+          </p>
+        </div>
+
+        <Form<RegisterFormValues>
+          form={form}
+          onFinish={handleSubmit}
+          size="large"
+          autoComplete="off"
+        >
+          <Form.Item
+            name="invite_code"
+            rules={[{ required: true, message: '请输入邀请码' }]}
+          >
+            <Input
+              prefix={<KeyOutlined />}
+              placeholder="请输入邀请码"
+              onChange={handleCodeChange}
+              onBlur={handleCodeBlur}
+            />
+          </Form.Item>
+
+          {/* Invite code validation feedback */}
+          {(validating || codeValidation) && (
+            <div style={{ marginTop: -16, marginBottom: 16, fontSize: 13 }}>
+              {validating && (
+                <span style={{ color: '#8c8c8c' }}>验证中...</span>
+              )}
+              {!validating && codeValidation?.valid && (
+                <span style={{ color: '#52c41a' }}>
+                  关联老人：{codeValidation.elder_name}
+                </span>
+              )}
+              {!validating && codeValidation && !codeValidation.valid && (
+                <span style={{ color: '#ff4d4f' }}>邀请码无效</span>
+              )}
+            </div>
+          )}
+
+          <Form.Item
+            name="real_name"
+            rules={[{ required: true, message: '请输入姓名' }]}
+          >
+            <Input prefix={<UserOutlined />} placeholder="请输入姓名" />
+          </Form.Item>
+
+          <Form.Item
+            name="phone"
+            rules={[
+              { required: true, message: '请输入手机号' },
+              { pattern: /^1\d{10}$/, message: '请输入正确的手机号' },
+            ]}
+          >
+            <Input prefix={<PhoneOutlined />} placeholder="请输入手机号" />
+          </Form.Item>
+
+          <Form.Item
+            name="password"
+            rules={[
+              { required: true, message: '请设置密码' },
+              { min: 6, message: '密码至少6位' },
+            ]}
+          >
+            <Input.Password prefix={<LockOutlined />} placeholder="请设置密码（至少6位）" />
+          </Form.Item>
+
+          <Form.Item
+            name="confirm_password"
+            dependencies={['password']}
+            rules={[
+              { required: true, message: '请确认密码' },
+              ({ getFieldValue }) => ({
+                validator(_, value) {
+                  if (!value || getFieldValue('password') === value) {
+                    return Promise.resolve();
+                  }
+                  return Promise.reject(new Error('两次密码不一致'));
+                },
+              }),
+            ]}
+          >
+            <Input.Password prefix={<LockOutlined />} placeholder="请确认密码" />
+          </Form.Item>
+
+          <Form.Item
+            name="relationship"
+            rules={[{ required: true, message: '请选择与老人的关系' }]}
+          >
+            <Select
+              placeholder="请选择与老人的关系"
+              options={relationshipOptions}
+              suffixIcon={<TeamOutlined />}
+            />
+          </Form.Item>
+
+          <Form.Item>
+            <Button type="primary" htmlType="submit" loading={loading} block>
+              注 册
+            </Button>
+          </Form.Item>
+        </Form>
+
+        <div style={{ textAlign: 'center', marginTop: -8 }}>
+          <Button type="link" onClick={() => navigate('/login')}>
+            返回登录
+          </Button>
+        </div>
+      </Card>
+
+      <SlideCaptcha
+        visible={captchaVisible}
+        sessionId={sessionId}
+        onSuccess={handleCaptchaSuccess}
+        onCancel={handleCaptchaCancel}
+      />
+    </>
+  );
+};
+
+export default FamilyRegisterPage;

--- a/frontend/src/pages/login/LoginPage.tsx
+++ b/frontend/src/pages/login/LoginPage.tsx
@@ -2,7 +2,7 @@ import React, { useState, useMemo } from 'react';
 import { Form, Input, Button, Card, message } from 'antd';
 import { UserOutlined, LockOutlined } from '@ant-design/icons';
 import { useNavigate } from 'react-router-dom';
-import { useAuthStore } from '../../store/auth';
+import { useAuthStore, getHomeRoute } from '../../store/auth';
 import SlideCaptcha from '../../components/SlideCaptcha';
 
 interface LoginFormValues {
@@ -36,8 +36,10 @@ const LoginPage: React.FC = () => {
         captcha_token: captchaToken,
         session_id: sessionId,
       });
+      const user = useAuthStore.getState().user;
+      const homeRoute = user ? getHomeRoute(user.roles) : '/dashboard';
       message.success('登录成功');
-      navigate('/dashboard', { replace: true });
+      navigate(homeRoute, { replace: true });
     } catch (err) {
       message.error(err instanceof Error ? err.message : '登录失败');
     } finally {

--- a/frontend/src/pages/login/LoginPage.tsx
+++ b/frontend/src/pages/login/LoginPage.tsx
@@ -96,6 +96,12 @@ const LoginPage: React.FC = () => {
             </Button>
           </Form.Item>
         </Form>
+
+        <div style={{ textAlign: 'center', marginTop: -8 }}>
+          <Button type="link" onClick={() => navigate('/register/family')}>
+            家属注册
+          </Button>
+        </div>
       </Card>
 
       <SlideCaptcha

--- a/frontend/src/router/index.tsx
+++ b/frontend/src/router/index.tsx
@@ -3,7 +3,7 @@ import { Routes, Route, Navigate } from 'react-router-dom';
 import { Spin } from 'antd';
 import BasicLayout from '../layouts/BasicLayout';
 import BlankLayout from '../layouts/BlankLayout';
-import { useAuthStore } from '../store/auth';
+import { useAuthStore, getHomeRoute } from '../store/auth';
 
 // Lazy-loaded pages
 const LoginPage = lazy(() => import('../pages/login/LoginPage'));
@@ -21,6 +21,9 @@ const ElderAccountPage = lazy(() => import('../pages/accounts/ElderAccountPage')
 const PersonalAccountPage = lazy(() => import('../pages/accounts/PersonalAccountPage'));
 const UserPage = lazy(() => import('../pages/system/UserPage'));
 const RolePage = lazy(() => import('../pages/system/RolePage'));
+const ElderLayout = lazy(() => import('../layouts/ElderLayout'));
+const ElderHomePage = lazy(() => import('../pages/elder-portal/ElderHomePage'));
+const ElderInvitePage = lazy(() => import('../pages/elder-portal/ElderInvitePage'));
 
 /** Loading fallback for lazy-loaded pages */
 const PageLoading: React.FC = () => (
@@ -36,6 +39,13 @@ const ProtectedRoute: React.FC<{ children: React.ReactNode }> = ({ children }) =
     return <Navigate to="/login" replace />;
   }
   return <>{children}</>;
+};
+
+/** Fallback redirect based on user role */
+const RoleBasedRedirect: React.FC = () => {
+  const user = useAuthStore((state) => state.user);
+  const target = user ? getHomeRoute(user.roles) : '/dashboard';
+  return <Navigate to={target} replace />;
 };
 
 const AppRouter: React.FC = () => {
@@ -72,8 +82,21 @@ const AppRouter: React.FC = () => {
           <Route path="/system/roles" element={<RolePage />} />
         </Route>
 
-        {/* Fallback */}
-        <Route path="*" element={<Navigate to="/dashboard" replace />} />
+        {/* Elder portal routes */}
+        <Route
+          element={
+            <ProtectedRoute>
+              <ElderLayout />
+            </ProtectedRoute>
+          }
+        >
+          <Route path="/elder" element={<ElderHomePage />} />
+          <Route path="/elder/invite" element={<ElderInvitePage />} />
+          <Route path="/elder/personal" element={<PersonalAccountPage />} />
+        </Route>
+
+        {/* Fallback — redirect based on role */}
+        <Route path="*" element={<RoleBasedRedirect />} />
       </Routes>
     </Suspense>
   );

--- a/frontend/src/router/index.tsx
+++ b/frontend/src/router/index.tsx
@@ -21,6 +21,10 @@ const ElderAccountPage = lazy(() => import('../pages/accounts/ElderAccountPage')
 const PersonalAccountPage = lazy(() => import('../pages/accounts/PersonalAccountPage'));
 const UserPage = lazy(() => import('../pages/system/UserPage'));
 const RolePage = lazy(() => import('../pages/system/RolePage'));
+const FamilyRegisterPage = lazy(() => import('../pages/family/FamilyRegisterPage'));
+const FamilyLayout = lazy(() => import('../layouts/FamilyLayout'));
+const FamilyHomePage = lazy(() => import('../pages/family-portal/FamilyHomePage'));
+const FamilyElderHealthPage = lazy(() => import('../pages/family-portal/FamilyElderHealthPage'));
 
 /** Loading fallback for lazy-loaded pages */
 const PageLoading: React.FC = () => (
@@ -45,6 +49,7 @@ const AppRouter: React.FC = () => {
         {/* Public routes */}
         <Route element={<BlankLayout />}>
           <Route path="/login" element={<LoginPage />} />
+          <Route path="/register/family" element={<FamilyRegisterPage />} />
         </Route>
 
         {/* Protected routes */}
@@ -70,6 +75,19 @@ const AppRouter: React.FC = () => {
           <Route path="/accounts/personal" element={<PersonalAccountPage />} />
           <Route path="/system/users" element={<UserPage />} />
           <Route path="/system/roles" element={<RolePage />} />
+        </Route>
+
+        {/* Family portal routes */}
+        <Route
+          element={
+            <ProtectedRoute>
+              <FamilyLayout />
+            </ProtectedRoute>
+          }
+        >
+          <Route path="/family" element={<FamilyHomePage />} />
+          <Route path="/family/elder" element={<FamilyElderHealthPage />} />
+          <Route path="/family/personal" element={<PersonalAccountPage />} />
         </Route>
 
         {/* Fallback */}

--- a/frontend/src/router/index.tsx
+++ b/frontend/src/router/index.tsx
@@ -11,16 +11,16 @@ const DashboardPage = lazy(() => import('../pages/dashboard/DashboardPage'));
 const ElderListPage = lazy(() => import('../pages/elders/ElderListPage'));
 const ElderDetailPage = lazy(() => import('../pages/elders/ElderDetailPage'));
 const ElderArchivePage = lazy(() => import('../pages/elders/ElderArchivePage'));
+const ElderArchiveListPage = lazy(() => import('../pages/elders/ElderArchiveListPage'));
 const AlertListPage = lazy(() => import('../pages/alerts/AlertListPage'));
 const AlertDetailPage = lazy(() => import('../pages/alerts/AlertDetailPage'));
 const FollowupPlanPage = lazy(() => import('../pages/followups/FollowupPlanPage'));
 const FollowupRecordPage = lazy(() => import('../pages/followups/FollowupRecordPage'));
 const InterventionPage = lazy(() => import('../pages/interventions/InterventionPage'));
 const AssessmentPage = lazy(() => import('../pages/assessments/AssessmentPage'));
-const ElderAccountPage = lazy(() => import('../pages/accounts/ElderAccountPage'));
 const PersonalAccountPage = lazy(() => import('../pages/accounts/PersonalAccountPage'));
-const UserPage = lazy(() => import('../pages/system/UserPage'));
-const RolePage = lazy(() => import('../pages/system/RolePage'));
+const DoctorPage = lazy(() => import('../pages/doctors/DoctorPage'));
+const FamilyMemberPage = lazy(() => import('../pages/family/FamilyMemberPage'));
 const ElderLayout = lazy(() => import('../layouts/ElderLayout'));
 const ElderHomePage = lazy(() => import('../pages/elder-portal/ElderHomePage'));
 const ElderInvitePage = lazy(() => import('../pages/elder-portal/ElderInvitePage'));
@@ -75,6 +75,7 @@ const AppRouter: React.FC = () => {
           <Route index element={<Navigate to="/dashboard" replace />} />
           <Route path="/dashboard" element={<DashboardPage />} />
           <Route path="/elders" element={<ElderListPage />} />
+          <Route path="/elders/archive" element={<ElderArchiveListPage />} />
           <Route path="/elders/:id" element={<ElderDetailPage />} />
           <Route path="/elders/:id/archive" element={<ElderArchivePage />} />
           <Route path="/alerts" element={<AlertListPage />} />
@@ -83,10 +84,9 @@ const AppRouter: React.FC = () => {
           <Route path="/followups/records" element={<FollowupRecordPage />} />
           <Route path="/interventions" element={<InterventionPage />} />
           <Route path="/assessments" element={<AssessmentPage />} />
-          <Route path="/accounts/elders" element={<ElderAccountPage />} />
+          <Route path="/doctors" element={<DoctorPage />} />
+          <Route path="/family-members" element={<FamilyMemberPage />} />
           <Route path="/accounts/personal" element={<PersonalAccountPage />} />
-          <Route path="/system/users" element={<UserPage />} />
-          <Route path="/system/roles" element={<RolePage />} />
         </Route>
 
         {/* Elder portal routes */}

--- a/frontend/src/router/index.tsx
+++ b/frontend/src/router/index.tsx
@@ -47,7 +47,9 @@ const ProtectedRoute: React.FC<{ children: React.ReactNode }> = ({ children }) =
 
 /** Fallback redirect based on user role */
 const RoleBasedRedirect: React.FC = () => {
+  const token = useAuthStore((state) => state.token);
   const user = useAuthStore((state) => state.user);
+  if (!token) return <Navigate to="/login" replace />;
   const target = user ? getHomeRoute(user.roles) : '/dashboard';
   return <Navigate to={target} replace />;
 };

--- a/frontend/src/store/auth.ts
+++ b/frontend/src/store/auth.ts
@@ -13,6 +13,13 @@ interface AuthState {
   loadFromStorage: () => void;
 }
 
+/** Determine home route based on user roles */
+export function getHomeRoute(roles: string[]): string {
+  if (roles.includes('elder')) return '/elder';
+  if (roles.includes('family')) return '/family';
+  return '/dashboard';
+}
+
 export const useAuthStore = create<AuthState>((set) => ({
   user: null,
   token: getToken(),

--- a/frontend/src/types/auth.ts
+++ b/frontend/src/types/auth.ts
@@ -36,6 +36,7 @@ export interface UserInfo {
   status?: string;
   roles: string[];
   permissions: string[];
+  elder_id?: number;
   created_at?: string;
 }
 

--- a/frontend/src/types/elder.ts
+++ b/frontend/src/types/elder.ts
@@ -13,6 +13,8 @@ export interface Elder {
   emergency_contact_name: string;
   emergency_contact_phone: string;
   tags: string[];
+  username?: string;
+  family_count?: number;
   created_at: string;
   updated_at?: string;
 }

--- a/frontend/src/types/family.ts
+++ b/frontend/src/types/family.ts
@@ -1,0 +1,28 @@
+export interface FamilyMemberInfo {
+  id: number;
+  user_id: number;
+  elder_id: number;
+  relationship: string;
+  real_name: string;
+  phone: string;
+  elder_name: string;
+  created_at?: string;
+}
+
+export interface FamilyElderInfo {
+  elder_id: number;
+  name: string;
+  gender: string;
+  birth_date?: string;
+  phone: string;
+  address: string;
+  emergency_contact_name: string;
+  emergency_contact_phone: string;
+  tags: string[];
+}
+
+export interface InviteCodeValidation {
+  valid: boolean;
+  elder_name: string;
+  remaining_slots: number;
+}

--- a/frontend/src/types/family.ts
+++ b/frontend/src/types/family.ts
@@ -21,6 +21,19 @@ export interface FamilyElderInfo {
   tags: string[];
 }
 
+/** Admin view of a family member */
+export interface FamilyMemberAdmin {
+  id: number;
+  user_id: number;
+  elder_id: number;
+  relationship: string;
+  username: string;
+  real_name: string;
+  phone: string;
+  elder_name: string;
+  created_at: string;
+}
+
 export interface InviteCodeValidation {
   valid: boolean;
   elder_name: string;


### PR DESCRIPTION
## Summary

- **Elder & Family roles**: Added 2 new user roles (elder, family) with full backend/frontend support
  - Elder accounts activated by admin/doctor, with invite code system (8-char codes, 7-day expiry, max 3 uses)
  - Family members self-register via invite codes with captcha verification
  - Dedicated elder portal (health summary, invite management) and family portal (view elder health)
- **Phone login**: Elders and family members can log in with phone number or username
- **User management restructure**: Replaced generic user/role management with dedicated pages
  - Doctor management page (CRUD with role filter)
  - Family member admin listing page (read-only)
  - Elder list page now includes account actions (activate, reset password, enable/disable)
  - Elder responses enriched with username and family_count
  - Removed role management page (角色管理)
- **Bug fixes**:
  - Fixed NaN bug on elder archive page (`/elders/archive` route ordering)
  - Fixed user info/permissions not restored on page refresh
  - Fixed SQLAlchemy column name shadowing in FamilyMember model
  - Phone now required when creating elder profiles

## Test plan

- [ ] Login as admin → verify sidebar shows 医生管理, 家属管理 (no 系统管理)
- [ ] Doctor management: create, edit, delete doctor accounts
- [ ] Elder list: verify username, family_count columns; activate account, reset password, toggle status
- [ ] Elder archive: click sidebar 老人档案 → card grid loads (no NaN error)
- [ ] Family member listing: verify admin can see all family members
- [ ] Phone login: log in with phone number instead of username
- [ ] Elder portal: login as elder → redirected to /elder, can generate invite codes
- [ ] Family registration: visit /register/family → register with invite code → login → family portal

🤖 Generated with [Claude Code](https://claude.com/claude-code)