### PR TITLE
refactor(frontend): migrate UI to Material UI

### DIFF
--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+npm-debug.log*
+.DS_Store

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -4,7 +4,7 @@ FROM node:22-alpine AS build
 WORKDIR /app
 
 COPY package.json package-lock.json ./
-RUN npm config set registry https://registry.npmmirror.com && npm ci
+RUN npm config set registry https://registry.npmmirror.com && npm install
 
 COPY . .
 RUN npm run build

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -4,7 +4,7 @@ FROM node:22-alpine AS build
 WORKDIR /app
 
 COPY package.json package-lock.json ./
-RUN npm config set registry https://registry.npmmirror.com && npm ci
+RUN npm config set registry https://registry.npmmirror.com && npm install --no-audit --no-fund
 
 COPY . .
 RUN npm run build

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,8 +8,11 @@
       "name": "smartmedcare-frontend",
       "version": "1.0.0",
       "dependencies": {
-        "@ant-design/icons": "^5.5.0",
-        "antd": "^5.22.0",
+        "@emotion/react": "^11.14.0",
+        "@emotion/styled": "^11.14.1",
+        "@mui/icons-material": "^7.3.4",
+        "@mui/material": "^7.3.4",
+        "@mui/x-date-pickers": "^8.11.3",
         "axios": "^1.7.0",
         "dayjs": "^1.11.13",
         "echarts": "^5.5.0",
@@ -27,92 +30,8 @@
         "vite": "^6.0.0"
       }
     },
-    "node_modules/@ant-design/colors": {
-      "version": "7.2.1",
-      "license": "MIT",
-      "dependencies": {
-        "@ant-design/fast-color": "^2.0.6"
-      }
-    },
-    "node_modules/@ant-design/cssinjs": {
-      "version": "1.24.0",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.11.1",
-        "@emotion/hash": "^0.8.0",
-        "@emotion/unitless": "^0.7.5",
-        "classnames": "^2.3.1",
-        "csstype": "^3.1.3",
-        "rc-util": "^5.35.0",
-        "stylis": "^4.3.4"
-      },
-      "peerDependencies": {
-        "react": ">=16.0.0",
-        "react-dom": ">=16.0.0"
-      }
-    },
-    "node_modules/@ant-design/cssinjs-utils": {
-      "version": "1.1.3",
-      "license": "MIT",
-      "dependencies": {
-        "@ant-design/cssinjs": "^1.21.0",
-        "@babel/runtime": "^7.23.2",
-        "rc-util": "^5.38.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/@ant-design/fast-color": {
-      "version": "2.0.6",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.24.7"
-      },
-      "engines": {
-        "node": ">=8.x"
-      }
-    },
-    "node_modules/@ant-design/icons": {
-      "version": "5.6.1",
-      "license": "MIT",
-      "dependencies": {
-        "@ant-design/colors": "^7.0.0",
-        "@ant-design/icons-svg": "^4.4.0",
-        "@babel/runtime": "^7.24.8",
-        "classnames": "^2.2.6",
-        "rc-util": "^5.31.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "peerDependencies": {
-        "react": ">=16.0.0",
-        "react-dom": ">=16.0.0"
-      }
-    },
-    "node_modules/@ant-design/icons-svg": {
-      "version": "4.4.2",
-      "license": "MIT"
-    },
-    "node_modules/@ant-design/react-slick": {
-      "version": "1.1.2",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.10.4",
-        "classnames": "^2.2.5",
-        "json2mq": "^0.2.0",
-        "resize-observer-polyfill": "^1.5.1",
-        "throttle-debounce": "^5.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0"
-      }
-    },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.28.5",
@@ -162,7 +81,6 @@
     },
     "node_modules/@babel/generator": {
       "version": "7.29.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.29.0",
@@ -192,7 +110,6 @@
     },
     "node_modules/@babel/helper-globals": {
       "version": "7.28.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -200,7 +117,6 @@
     },
     "node_modules/@babel/helper-module-imports": {
       "version": "7.28.6",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/traverse": "^7.28.6",
@@ -236,7 +152,6 @@
     },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.27.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -244,7 +159,6 @@
     },
     "node_modules/@babel/helper-validator-identifier": {
       "version": "7.28.5",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -272,7 +186,6 @@
     },
     "node_modules/@babel/parser": {
       "version": "7.29.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.29.0"
@@ -321,7 +234,6 @@
     },
     "node_modules/@babel/template": {
       "version": "7.28.6",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
@@ -334,7 +246,6 @@
     },
     "node_modules/@babel/traverse": {
       "version": "7.29.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
@@ -351,7 +262,6 @@
     },
     "node_modules/@babel/types": {
       "version": "7.29.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
@@ -361,12 +271,174 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@emotion/hash": {
-      "version": "0.8.0",
+    "node_modules/@emotion/babel-plugin": {
+      "version": "11.13.5",
+      "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.13.5.tgz",
+      "integrity": "sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.16.7",
+        "@babel/runtime": "^7.18.3",
+        "@emotion/hash": "^0.9.2",
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/serialize": "^1.3.3",
+        "babel-plugin-macros": "^3.1.0",
+        "convert-source-map": "^1.5.0",
+        "escape-string-regexp": "^4.0.0",
+        "find-root": "^1.1.0",
+        "source-map": "^0.5.7",
+        "stylis": "4.2.0"
+      }
+    },
+    "node_modules/@emotion/babel-plugin/node_modules/@emotion/hash": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
+      "integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==",
       "license": "MIT"
     },
-    "node_modules/@emotion/unitless": {
-      "version": "0.7.5",
+    "node_modules/@emotion/babel-plugin/node_modules/convert-source-map": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
+      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/babel-plugin/node_modules/stylis": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
+      "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/cache": {
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.14.0.tgz",
+      "integrity": "sha512-L/B1lc/TViYk4DcpGxtAVbx0ZyiKM5ktoIyafGkH6zg/tj+mA+NE//aPYKG0k8kCHSHVJrpLpcAlOBEXQ3SavA==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/sheet": "^1.4.0",
+        "@emotion/utils": "^1.4.2",
+        "@emotion/weak-memoize": "^0.4.0",
+        "stylis": "4.2.0"
+      }
+    },
+    "node_modules/@emotion/cache/node_modules/stylis": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
+      "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/is-prop-valid": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.4.0.tgz",
+      "integrity": "sha512-QgD4fyscGcbbKwJmqNvUMSE02OsHUa+lAWKdEUIJKgqe5IwRSKd7+KhibEWdaKwgjLj0DRSHA9biAIqGBk05lw==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/memoize": "^0.9.0"
+      }
+    },
+    "node_modules/@emotion/memoize": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
+      "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/react": {
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
+      "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "@emotion/babel-plugin": "^11.13.5",
+        "@emotion/cache": "^11.14.0",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/use-insertion-effect-with-fallbacks": "^1.2.0",
+        "@emotion/utils": "^1.4.2",
+        "@emotion/weak-memoize": "^0.4.0",
+        "hoist-non-react-statics": "^3.3.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@emotion/serialize": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.3.3.tgz",
+      "integrity": "sha512-EISGqt7sSNWHGI76hC7x1CksiXPahbxEOrC5RjmFRJTqLyEK9/9hZvBbiYn70dw4wuwMKiEMCUlR6ZXTSWQqxA==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/hash": "^0.9.2",
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/unitless": "^0.10.0",
+        "@emotion/utils": "^1.4.2",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@emotion/serialize/node_modules/@emotion/hash": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
+      "integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/serialize/node_modules/@emotion/unitless": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.10.0.tgz",
+      "integrity": "sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/sheet": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.4.0.tgz",
+      "integrity": "sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/styled": {
+      "version": "11.14.1",
+      "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.14.1.tgz",
+      "integrity": "sha512-qEEJt42DuToa3gurlH4Qqc1kVpNq8wO8cJtDzU46TjlzWjDlsVyevtYCRijVq3SrHsROS+gVQ8Fnea108GnKzw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "@emotion/babel-plugin": "^11.13.5",
+        "@emotion/is-prop-valid": "^1.3.0",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/use-insertion-effect-with-fallbacks": "^1.2.0",
+        "@emotion/utils": "^1.4.2"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.0.0-rc.0",
+        "react": ">=16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@emotion/use-insertion-effect-with-fallbacks": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.2.0.tgz",
+      "integrity": "sha512-yJMtVdH59sxi/aVJBpk9FQq+OR8ll5GT8oWd57UpeaKEVGab41JWaCFA7FRLoMLloOZF/c/wsPoe+bfGmRKgDg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@emotion/utils": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.4.2.tgz",
+      "integrity": "sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/weak-memoize": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz",
+      "integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==",
       "license": "MIT"
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -811,7 +883,6 @@
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -829,7 +900,6 @@
     },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -837,145 +907,357 @@
     },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@rc-component/async-validator": {
-      "version": "5.1.0",
+    "node_modules/@mui/core-downloads-tracker": {
+      "version": "7.3.10",
+      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-7.3.10.tgz",
+      "integrity": "sha512-vrOpWRmPJSuwLo23J62wggEm/jvGdzqctej+UOCtgDUz6nZJQuj3ByPccVyaa7eQmwAzUwKN56FQPMKkqbj1GA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      }
+    },
+    "node_modules/@mui/icons-material": {
+      "version": "7.3.10",
+      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-7.3.10.tgz",
+      "integrity": "sha512-Au0ma4NSKGKNiimukj8UT/W1x2Qx6Qwn2RvFGykiSqVLYBNlIOPbjnIMvrwLGLu89EEpTVdu/ys/OduZR+tWqw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.24.4"
+        "@babel/runtime": "^7.28.6"
       },
       "engines": {
-        "node": ">=14.x"
-      }
-    },
-    "node_modules/@rc-component/color-picker": {
-      "version": "2.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "@ant-design/fast-color": "^2.0.6",
-        "@babel/runtime": "^7.23.6",
-        "classnames": "^2.2.6",
-        "rc-util": "^5.38.1"
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
       },
       "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/@rc-component/context": {
-      "version": "1.4.0",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.10.1",
-        "rc-util": "^5.27.0"
+        "@mui/material": "^7.3.10",
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
       },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
-    "node_modules/@rc-component/mini-decimal": {
-      "version": "1.1.3",
+    "node_modules/@mui/material": {
+      "version": "7.3.10",
+      "resolved": "https://registry.npmjs.org/@mui/material/-/material-7.3.10.tgz",
+      "integrity": "sha512-cHvGOk2ZEfbQt3LnGe0ZKd/ETs9gsUpkW66DCO+GSjMZhpdKU4XsuIr7zJ/B/2XaN8ihxuzHfYAR4zPtCN4RYg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.18.0"
+        "@babel/runtime": "^7.28.6",
+        "@mui/core-downloads-tracker": "^7.3.10",
+        "@mui/system": "^7.3.10",
+        "@mui/types": "^7.4.12",
+        "@mui/utils": "^7.3.10",
+        "@popperjs/core": "^2.11.8",
+        "@types/react-transition-group": "^4.4.12",
+        "clsx": "^2.1.1",
+        "csstype": "^3.2.3",
+        "prop-types": "^15.8.1",
+        "react-is": "^19.2.3",
+        "react-transition-group": "^4.4.5"
       },
       "engines": {
-        "node": ">=8.x"
-      }
-    },
-    "node_modules/@rc-component/mutate-observer": {
-      "version": "1.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.18.0",
-        "classnames": "^2.3.2",
-        "rc-util": "^5.24.4"
+        "node": ">=14.0.0"
       },
-      "engines": {
-        "node": ">=8.x"
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
       },
       "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
+        "@emotion/react": "^11.5.0",
+        "@emotion/styled": "^11.3.0",
+        "@mui/material-pigment-css": "^7.3.10",
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        },
+        "@mui/material-pigment-css": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        }
       }
     },
-    "node_modules/@rc-component/portal": {
-      "version": "1.1.2",
+    "node_modules/@mui/material/node_modules/react-is": {
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.5.tgz",
+      "integrity": "sha512-Dn0t8IQhCmeIT3wu+Apm1/YVsJXsGWi6k4sPdnBIdqMVtHtv0IGi6dcpNpNkNac0zB2uUAqNX3MHzN8c+z2rwQ==",
+      "license": "MIT"
+    },
+    "node_modules/@mui/private-theming": {
+      "version": "7.3.10",
+      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-7.3.10.tgz",
+      "integrity": "sha512-j3EZN+zOctxUISvJSmsEPo5o2F8zse4l5vRkBY+ps6UtnL6J7o14kUaI4w7gwo73id9e3cDNMVQK/9BVaMHVBw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.18.0",
-        "classnames": "^2.3.2",
-        "rc-util": "^5.24.4"
+        "@babel/runtime": "^7.28.6",
+        "@mui/utils": "^7.3.10",
+        "prop-types": "^15.8.1"
       },
       "engines": {
-        "node": ">=8.x"
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
       },
       "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
-    "node_modules/@rc-component/qrcode": {
-      "version": "1.1.1",
+    "node_modules/@mui/styled-engine": {
+      "version": "7.3.10",
+      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-7.3.10.tgz",
+      "integrity": "sha512-WxE9SiF8xskAQqGjsp0poXCkCqsoXFEsSr0HBXfApmGHR+DBnXRp+z46Vsltg4gpPM4Z96DeAQRpeAOnhNg7Ng==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.24.7"
+        "@babel/runtime": "^7.28.6",
+        "@emotion/cache": "^11.14.0",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/sheet": "^1.4.0",
+        "csstype": "^3.2.3",
+        "prop-types": "^15.8.1"
       },
       "engines": {
-        "node": ">=8.x"
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
       },
       "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
+        "@emotion/react": "^11.4.1",
+        "@emotion/styled": "^11.3.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        }
       }
     },
-    "node_modules/@rc-component/tour": {
-      "version": "1.15.1",
+    "node_modules/@mui/system": {
+      "version": "7.3.10",
+      "resolved": "https://registry.npmjs.org/@mui/system/-/system-7.3.10.tgz",
+      "integrity": "sha512-/sfPpdpJaQn7BSF+avjIdHSYmxHp0UOBYNxSG9QGKfMOD6sLANCpRPCnanq1Pe0lFf0NHkO2iUk0TNzdWC1USQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.18.0",
-        "@rc-component/portal": "^1.0.0-9",
-        "@rc-component/trigger": "^2.0.0",
-        "classnames": "^2.3.2",
-        "rc-util": "^5.24.4"
+        "@babel/runtime": "^7.28.6",
+        "@mui/private-theming": "^7.3.10",
+        "@mui/styled-engine": "^7.3.10",
+        "@mui/types": "^7.4.12",
+        "@mui/utils": "^7.3.10",
+        "clsx": "^2.1.1",
+        "csstype": "^3.2.3",
+        "prop-types": "^15.8.1"
       },
       "engines": {
-        "node": ">=8.x"
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
       },
       "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
+        "@emotion/react": "^11.5.0",
+        "@emotion/styled": "^11.3.0",
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        }
       }
     },
-    "node_modules/@rc-component/trigger": {
-      "version": "2.3.1",
+    "node_modules/@mui/types": {
+      "version": "7.4.12",
+      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.4.12.tgz",
+      "integrity": "sha512-iKNAF2u9PzSIj40CjvKJWxFXJo122jXVdrmdh0hMYd+FR+NuJMkr/L88XwWLCRiJ5P1j+uyac25+Kp6YC4hu6w==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.23.2",
-        "@rc-component/portal": "^1.1.0",
-        "classnames": "^2.3.2",
-        "rc-motion": "^2.0.0",
-        "rc-resize-observer": "^1.3.1",
-        "rc-util": "^5.44.0"
-      },
-      "engines": {
-        "node": ">=8.x"
+        "@babel/runtime": "^7.28.6"
       },
       "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/utils": {
+      "version": "7.3.10",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-7.3.10.tgz",
+      "integrity": "sha512-7y2eIfy0h7JPz+Yy4pS+wgV68d46PuuxDqKBN4Q8VlPQSsCAGwroMCV6xWyc7g9dvEp8ZNFsknc59GHWO+r6Ow==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.6",
+        "@mui/types": "^7.4.12",
+        "@types/prop-types": "^15.7.15",
+        "clsx": "^2.1.1",
+        "prop-types": "^15.8.1",
+        "react-is": "^19.2.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/utils/node_modules/react-is": {
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.5.tgz",
+      "integrity": "sha512-Dn0t8IQhCmeIT3wu+Apm1/YVsJXsGWi6k4sPdnBIdqMVtHtv0IGi6dcpNpNkNac0zB2uUAqNX3MHzN8c+z2rwQ==",
+      "license": "MIT"
+    },
+    "node_modules/@mui/x-date-pickers": {
+      "version": "8.27.2",
+      "resolved": "https://registry.npmjs.org/@mui/x-date-pickers/-/x-date-pickers-8.27.2.tgz",
+      "integrity": "sha512-06LFkHFRXJ2O9DMXtWAA3kY0jpbL7XH8iqa8L5cBlN+8bRx/UVLKlZYlhGv06C88jF9kuZWY1bUgrv/EoY/2Ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.4",
+        "@mui/utils": "^7.3.5",
+        "@mui/x-internals": "8.26.0",
+        "@types/react-transition-group": "^4.4.12",
+        "clsx": "^2.1.1",
+        "prop-types": "^15.8.1",
+        "react-transition-group": "^4.4.5"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.9.0",
+        "@emotion/styled": "^11.8.1",
+        "@mui/material": "^5.15.14 || ^6.0.0 || ^7.0.0",
+        "@mui/system": "^5.15.14 || ^6.0.0 || ^7.0.0",
+        "date-fns": "^2.25.0 || ^3.2.0 || ^4.0.0",
+        "date-fns-jalali": "^2.13.0-0 || ^3.2.0-0 || ^4.0.0-0",
+        "dayjs": "^1.10.7",
+        "luxon": "^3.0.2",
+        "moment": "^2.29.4",
+        "moment-hijri": "^2.1.2 || ^3.0.0",
+        "moment-jalaali": "^0.7.4 || ^0.8.0 || ^0.9.0 || ^0.10.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        },
+        "date-fns": {
+          "optional": true
+        },
+        "date-fns-jalali": {
+          "optional": true
+        },
+        "dayjs": {
+          "optional": true
+        },
+        "luxon": {
+          "optional": true
+        },
+        "moment": {
+          "optional": true
+        },
+        "moment-hijri": {
+          "optional": true
+        },
+        "moment-jalaali": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/x-internals": {
+      "version": "8.26.0",
+      "resolved": "https://registry.npmjs.org/@mui/x-internals/-/x-internals-8.26.0.tgz",
+      "integrity": "sha512-B9OZau5IQUvIxwpJZhoFJKqRpmWf5r0yMmSXjQuqb5WuqM755EuzWJOenY48denGoENzMLT8hQpA0hRTeU2IPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.4",
+        "@mui/utils": "^7.3.5",
+        "reselect": "^5.1.1",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@popperjs/core": {
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
       }
     },
     "node_modules/@remix-run/router": {
@@ -1380,14 +1662,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/parse-json": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
+      "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==",
+      "license": "MIT"
+    },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.28",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -1400,6 +1686,15 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@types/react-transition-group": {
+      "version": "4.4.12",
+      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.12.tgz",
+      "integrity": "sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*"
       }
     },
     "node_modules/@vitejs/plugin-react": {
@@ -1421,69 +1716,6 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
-    "node_modules/antd": {
-      "version": "5.29.3",
-      "license": "MIT",
-      "dependencies": {
-        "@ant-design/colors": "^7.2.1",
-        "@ant-design/cssinjs": "^1.23.0",
-        "@ant-design/cssinjs-utils": "^1.1.3",
-        "@ant-design/fast-color": "^2.0.6",
-        "@ant-design/icons": "^5.6.1",
-        "@ant-design/react-slick": "~1.1.2",
-        "@babel/runtime": "^7.26.0",
-        "@rc-component/color-picker": "~2.0.1",
-        "@rc-component/mutate-observer": "^1.1.0",
-        "@rc-component/qrcode": "~1.1.0",
-        "@rc-component/tour": "~1.15.1",
-        "@rc-component/trigger": "^2.3.0",
-        "classnames": "^2.5.1",
-        "copy-to-clipboard": "^3.3.3",
-        "dayjs": "^1.11.11",
-        "rc-cascader": "~3.34.0",
-        "rc-checkbox": "~3.5.0",
-        "rc-collapse": "~3.9.0",
-        "rc-dialog": "~9.6.0",
-        "rc-drawer": "~7.3.0",
-        "rc-dropdown": "~4.2.1",
-        "rc-field-form": "~2.7.1",
-        "rc-image": "~7.12.0",
-        "rc-input": "~1.8.0",
-        "rc-input-number": "~9.5.0",
-        "rc-mentions": "~2.20.0",
-        "rc-menu": "~9.16.1",
-        "rc-motion": "^2.9.5",
-        "rc-notification": "~5.6.4",
-        "rc-pagination": "~5.1.0",
-        "rc-picker": "~4.11.3",
-        "rc-progress": "~4.0.0",
-        "rc-rate": "~2.13.1",
-        "rc-resize-observer": "^1.4.3",
-        "rc-segmented": "~2.7.0",
-        "rc-select": "~14.16.8",
-        "rc-slider": "~11.1.9",
-        "rc-steps": "~6.0.1",
-        "rc-switch": "~4.1.0",
-        "rc-table": "~7.54.0",
-        "rc-tabs": "~15.7.0",
-        "rc-textarea": "~1.10.2",
-        "rc-tooltip": "~6.4.0",
-        "rc-tree": "~5.13.1",
-        "rc-tree-select": "~5.27.0",
-        "rc-upload": "~4.11.0",
-        "rc-util": "^5.44.4",
-        "scroll-into-view-if-needed": "^3.1.0",
-        "throttle-debounce": "^5.0.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/ant-design"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "license": "MIT"
@@ -1495,6 +1727,21 @@
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
         "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/babel-plugin-macros": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
+      "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "cosmiconfig": "^7.0.0",
+        "resolve": "^1.19.0"
+      },
+      "engines": {
+        "node": ">=10",
+        "npm": ">=6"
       }
     },
     "node_modules/baseline-browser-mapping": {
@@ -1551,6 +1798,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001788",
       "dev": true,
@@ -1570,9 +1826,14 @@
       ],
       "license": "CC-BY-4.0"
     },
-    "node_modules/classnames": {
-      "version": "2.5.1",
-      "license": "MIT"
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -1584,20 +1845,34 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/compute-scroll-into-view": {
-      "version": "3.1.1",
-      "license": "MIT"
-    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/copy-to-clipboard": {
-      "version": "3.3.3",
+    "node_modules/cosmiconfig": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
       "license": "MIT",
       "dependencies": {
-        "toggle-selection": "^1.0.6"
+        "@types/parse-json": "^4.0.0",
+        "import-fresh": "^3.2.1",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0",
+        "yaml": "^1.10.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/cosmiconfig/node_modules/yaml": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/csstype": {
@@ -1610,7 +1885,6 @@
     },
     "node_modules/debug": {
       "version": "4.4.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -1629,6 +1903,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dom-helpers": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
       }
     },
     "node_modules/dunder-proto": {
@@ -1667,6 +1951,15 @@
       "version": "1.5.336",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
     },
     "node_modules/es-define-property": {
       "version": "1.0.1",
@@ -1753,6 +2046,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "license": "MIT"
@@ -1772,6 +2077,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/find-root": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
+      "license": "MIT"
     },
     "node_modules/follow-redirects": {
       "version": "1.16.0",
@@ -1911,13 +2222,64 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
+    "node_modules/hoist-non-react-statics/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "license": "MIT"
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "license": "MIT"
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "jsesc": "bin/jsesc"
@@ -1926,12 +2288,11 @@
         "node": ">=6"
       }
     },
-    "node_modules/json2mq": {
-      "version": "0.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "string-convert": "^0.2.0"
-      }
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "license": "MIT"
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -1943,6 +2304,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "license": "MIT"
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -1988,7 +2355,6 @@
     },
     "node_modules/ms": {
       "version": "2.1.3",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -2013,9 +2379,62 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "license": "MIT"
+    },
+    "node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
@@ -2056,549 +2475,28 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
     "node_modules/proxy-from-env": {
       "version": "2.1.0",
       "license": "MIT",
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/rc-cascader": {
-      "version": "3.34.0",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.25.7",
-        "classnames": "^2.3.1",
-        "rc-select": "~14.16.2",
-        "rc-tree": "~5.13.0",
-        "rc-util": "^5.43.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/rc-checkbox": {
-      "version": "3.5.0",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.10.1",
-        "classnames": "^2.3.2",
-        "rc-util": "^5.25.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/rc-collapse": {
-      "version": "3.9.0",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.10.1",
-        "classnames": "2.x",
-        "rc-motion": "^2.3.4",
-        "rc-util": "^5.27.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/rc-dialog": {
-      "version": "9.6.0",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.10.1",
-        "@rc-component/portal": "^1.0.0-8",
-        "classnames": "^2.2.6",
-        "rc-motion": "^2.3.0",
-        "rc-util": "^5.21.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/rc-drawer": {
-      "version": "7.3.0",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.23.9",
-        "@rc-component/portal": "^1.1.1",
-        "classnames": "^2.2.6",
-        "rc-motion": "^2.6.1",
-        "rc-util": "^5.38.1"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/rc-dropdown": {
-      "version": "4.2.1",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.18.3",
-        "@rc-component/trigger": "^2.0.0",
-        "classnames": "^2.2.6",
-        "rc-util": "^5.44.1"
-      },
-      "peerDependencies": {
-        "react": ">=16.11.0",
-        "react-dom": ">=16.11.0"
-      }
-    },
-    "node_modules/rc-field-form": {
-      "version": "2.7.1",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.18.0",
-        "@rc-component/async-validator": "^5.0.3",
-        "rc-util": "^5.32.2"
-      },
-      "engines": {
-        "node": ">=8.x"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/rc-image": {
-      "version": "7.12.0",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.11.2",
-        "@rc-component/portal": "^1.0.2",
-        "classnames": "^2.2.6",
-        "rc-dialog": "~9.6.0",
-        "rc-motion": "^2.6.2",
-        "rc-util": "^5.34.1"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/rc-input": {
-      "version": "1.8.0",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.11.1",
-        "classnames": "^2.2.1",
-        "rc-util": "^5.18.1"
-      },
-      "peerDependencies": {
-        "react": ">=16.0.0",
-        "react-dom": ">=16.0.0"
-      }
-    },
-    "node_modules/rc-input-number": {
-      "version": "9.5.0",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.10.1",
-        "@rc-component/mini-decimal": "^1.0.1",
-        "classnames": "^2.2.5",
-        "rc-input": "~1.8.0",
-        "rc-util": "^5.40.1"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/rc-mentions": {
-      "version": "2.20.0",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.22.5",
-        "@rc-component/trigger": "^2.0.0",
-        "classnames": "^2.2.6",
-        "rc-input": "~1.8.0",
-        "rc-menu": "~9.16.0",
-        "rc-textarea": "~1.10.0",
-        "rc-util": "^5.34.1"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/rc-menu": {
-      "version": "9.16.1",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.10.1",
-        "@rc-component/trigger": "^2.0.0",
-        "classnames": "2.x",
-        "rc-motion": "^2.4.3",
-        "rc-overflow": "^1.3.1",
-        "rc-util": "^5.27.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/rc-motion": {
-      "version": "2.9.5",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.11.1",
-        "classnames": "^2.2.1",
-        "rc-util": "^5.44.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/rc-notification": {
-      "version": "5.6.4",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.10.1",
-        "classnames": "2.x",
-        "rc-motion": "^2.9.0",
-        "rc-util": "^5.20.1"
-      },
-      "engines": {
-        "node": ">=8.x"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/rc-overflow": {
-      "version": "1.5.0",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.11.1",
-        "classnames": "^2.2.1",
-        "rc-resize-observer": "^1.0.0",
-        "rc-util": "^5.37.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/rc-pagination": {
-      "version": "5.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.10.1",
-        "classnames": "^2.3.2",
-        "rc-util": "^5.38.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/rc-picker": {
-      "version": "4.11.3",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.24.7",
-        "@rc-component/trigger": "^2.0.0",
-        "classnames": "^2.2.1",
-        "rc-overflow": "^1.3.2",
-        "rc-resize-observer": "^1.4.0",
-        "rc-util": "^5.43.0"
-      },
-      "engines": {
-        "node": ">=8.x"
-      },
-      "peerDependencies": {
-        "date-fns": ">= 2.x",
-        "dayjs": ">= 1.x",
-        "luxon": ">= 3.x",
-        "moment": ">= 2.x",
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      },
-      "peerDependenciesMeta": {
-        "date-fns": {
-          "optional": true
-        },
-        "dayjs": {
-          "optional": true
-        },
-        "luxon": {
-          "optional": true
-        },
-        "moment": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/rc-progress": {
-      "version": "4.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.10.1",
-        "classnames": "^2.2.6",
-        "rc-util": "^5.16.1"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/rc-rate": {
-      "version": "2.13.1",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.10.1",
-        "classnames": "^2.2.5",
-        "rc-util": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8.x"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/rc-resize-observer": {
-      "version": "1.4.3",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.20.7",
-        "classnames": "^2.2.1",
-        "rc-util": "^5.44.1",
-        "resize-observer-polyfill": "^1.5.1"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/rc-segmented": {
-      "version": "2.7.1",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.11.1",
-        "classnames": "^2.2.1",
-        "rc-motion": "^2.4.4",
-        "rc-util": "^5.17.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.0.0",
-        "react-dom": ">=16.0.0"
-      }
-    },
-    "node_modules/rc-select": {
-      "version": "14.16.8",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.10.1",
-        "@rc-component/trigger": "^2.1.1",
-        "classnames": "2.x",
-        "rc-motion": "^2.0.1",
-        "rc-overflow": "^1.3.1",
-        "rc-util": "^5.16.1",
-        "rc-virtual-list": "^3.5.2"
-      },
-      "engines": {
-        "node": ">=8.x"
-      },
-      "peerDependencies": {
-        "react": "*",
-        "react-dom": "*"
-      }
-    },
-    "node_modules/rc-slider": {
-      "version": "11.1.9",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.10.1",
-        "classnames": "^2.2.5",
-        "rc-util": "^5.36.0"
-      },
-      "engines": {
-        "node": ">=8.x"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/rc-steps": {
-      "version": "6.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.16.7",
-        "classnames": "^2.2.3",
-        "rc-util": "^5.16.1"
-      },
-      "engines": {
-        "node": ">=8.x"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/rc-switch": {
-      "version": "4.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.21.0",
-        "classnames": "^2.2.1",
-        "rc-util": "^5.30.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/rc-table": {
-      "version": "7.54.0",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.10.1",
-        "@rc-component/context": "^1.4.0",
-        "classnames": "^2.2.5",
-        "rc-resize-observer": "^1.1.0",
-        "rc-util": "^5.44.3",
-        "rc-virtual-list": "^3.14.2"
-      },
-      "engines": {
-        "node": ">=8.x"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/rc-tabs": {
-      "version": "15.7.0",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.11.2",
-        "classnames": "2.x",
-        "rc-dropdown": "~4.2.0",
-        "rc-menu": "~9.16.0",
-        "rc-motion": "^2.6.2",
-        "rc-resize-observer": "^1.0.0",
-        "rc-util": "^5.34.1"
-      },
-      "engines": {
-        "node": ">=8.x"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/rc-textarea": {
-      "version": "1.10.2",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.10.1",
-        "classnames": "^2.2.1",
-        "rc-input": "~1.8.0",
-        "rc-resize-observer": "^1.0.0",
-        "rc-util": "^5.27.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/rc-tooltip": {
-      "version": "6.4.0",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.11.2",
-        "@rc-component/trigger": "^2.0.0",
-        "classnames": "^2.3.1",
-        "rc-util": "^5.44.3"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/rc-tree": {
-      "version": "5.13.1",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.10.1",
-        "classnames": "2.x",
-        "rc-motion": "^2.0.1",
-        "rc-util": "^5.16.1",
-        "rc-virtual-list": "^3.5.1"
-      },
-      "engines": {
-        "node": ">=10.x"
-      },
-      "peerDependencies": {
-        "react": "*",
-        "react-dom": "*"
-      }
-    },
-    "node_modules/rc-tree-select": {
-      "version": "5.27.0",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.25.7",
-        "classnames": "2.x",
-        "rc-select": "~14.16.2",
-        "rc-tree": "~5.13.0",
-        "rc-util": "^5.43.0"
-      },
-      "peerDependencies": {
-        "react": "*",
-        "react-dom": "*"
-      }
-    },
-    "node_modules/rc-upload": {
-      "version": "4.11.0",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.18.3",
-        "classnames": "^2.2.5",
-        "rc-util": "^5.2.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/rc-util": {
-      "version": "5.44.4",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.18.3",
-        "react-is": "^18.2.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/rc-virtual-list": {
-      "version": "3.19.2",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.20.0",
-        "classnames": "^2.2.6",
-        "rc-resize-observer": "^1.0.0",
-        "rc-util": "^5.36.0"
-      },
-      "engines": {
-        "node": ">=8.x"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
       }
     },
     "node_modules/react": {
@@ -2621,10 +2519,6 @@
       "peerDependencies": {
         "react": "^18.3.1"
       }
-    },
-    "node_modules/react-is": {
-      "version": "18.3.1",
-      "license": "MIT"
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",
@@ -2662,9 +2556,57 @@
         "react-dom": ">=16.8"
       }
     },
-    "node_modules/resize-observer-polyfill": {
-      "version": "1.5.1",
+    "node_modules/react-transition-group": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0",
+        "react-dom": ">=16.6.0"
+      }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
       "license": "MIT"
+    },
+    "node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/rollup": {
       "version": "4.60.1",
@@ -2716,13 +2658,6 @@
         "loose-envify": "^1.1.0"
       }
     },
-    "node_modules/scroll-into-view-if-needed": {
-      "version": "3.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "compute-scroll-into-view": "^3.0.2"
-      }
-    },
     "node_modules/semver": {
       "version": "6.3.1",
       "dev": true,
@@ -2735,6 +2670,15 @@
       "version": "1.0.3",
       "license": "ISC"
     },
+    "node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "dev": true,
@@ -2743,19 +2687,16 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/string-convert": {
-      "version": "0.2.1",
-      "license": "MIT"
-    },
-    "node_modules/stylis": {
-      "version": "4.3.6",
-      "license": "MIT"
-    },
-    "node_modules/throttle-debounce": {
-      "version": "5.0.2",
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
       "license": "MIT",
       "engines": {
-        "node": ">=12.22"
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/tinyglobby": {
@@ -2772,10 +2713,6 @@
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
-    },
-    "node_modules/toggle-selection": {
-      "version": "1.0.6",
-      "license": "MIT"
     },
     "node_modules/tslib": {
       "version": "2.3.0",
@@ -2820,6 +2757,15 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/vite": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,16 +9,19 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1",
-    "react-router-dom": "^6.28.0",
-    "antd": "^5.22.0",
-    "@ant-design/icons": "^5.5.0",
+    "@emotion/react": "^11.14.0",
+    "@emotion/styled": "^11.14.1",
+    "@mui/icons-material": "^7.3.4",
+    "@mui/material": "^7.3.4",
+    "@mui/x-date-pickers": "^8.11.3",
     "axios": "^1.7.0",
     "zustand": "^5.0.0",
     "dayjs": "^1.11.13",
     "echarts": "^5.5.0",
-    "echarts-for-react": "^3.0.2"
+    "echarts-for-react": "^3.0.2",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^6.28.0"
   },
   "devDependencies": {
     "@types/react": "^18.3.0",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,11 +1,14 @@
 import { useEffect, useState } from 'react';
 import { BrowserRouter } from 'react-router-dom';
-import { ConfigProvider, Spin } from 'antd';
-import zhCN from 'antd/locale/zh_CN';
+import { CircularProgress, CssBaseline, ThemeProvider } from '@mui/material';
+import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
+import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import dayjs from 'dayjs';
 import 'dayjs/locale/zh-cn';
 import AppRouter from './router';
+import ToastProvider from './components/ToastProvider';
 import { useAuthStore } from './store/auth';
+import theme from './theme';
 
 dayjs.locale('zh-cn');
 
@@ -28,26 +31,26 @@ function App() {
 
   if (initializing) {
     return (
-      <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100vh' }}>
-        <Spin size="large" />
-      </div>
+      <ThemeProvider theme={theme}>
+        <CssBaseline />
+        <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100vh' }}>
+          <CircularProgress size={48} />
+        </div>
+      </ThemeProvider>
     );
   }
 
   return (
-    <ConfigProvider
-      locale={zhCN}
-      theme={{
-        token: {
-          colorPrimary: '#1677ff',
-          borderRadius: 6,
-        },
-      }}
-    >
-      <BrowserRouter>
-        <AppRouter />
-      </BrowserRouter>
-    </ConfigProvider>
+    <ThemeProvider theme={theme}>
+      <LocalizationProvider dateAdapter={AdapterDayjs} adapterLocale="zh-cn">
+        <ToastProvider>
+          <CssBaseline />
+          <BrowserRouter>
+            <AppRouter />
+          </BrowserRouter>
+        </ToastProvider>
+      </LocalizationProvider>
+    </ThemeProvider>
   );
 }
 

--- a/frontend/src/components/AppForm.tsx
+++ b/frontend/src/components/AppForm.tsx
@@ -1,5 +1,18 @@
-import React, { useEffect } from 'react';
-import { Modal, Form, Input, InputNumber, Select, DatePicker } from 'antd';
+import React, { useEffect, useMemo, useState } from 'react';
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+  Stack,
+  TextField,
+} from '@mui/material';
+import { DatePicker } from '@mui/x-date-pickers/DatePicker';
 import dayjs from 'dayjs';
 
 export interface FormFieldConfig {
@@ -24,10 +37,13 @@ interface AppFormProps<T = any> {
   width?: number;
 }
 
-/**
- * Reusable form component rendered inside a Modal.
- * Supports create and edit modes via initialValues.
- */
+function createDefaultValues(fields: FormFieldConfig[]) {
+  return fields.reduce<Record<string, unknown>>((result, field) => {
+    result[field.name] = '';
+    return result;
+  }, {});
+}
+
 const AppForm: React.FC<AppFormProps> = ({
   title,
   visible,
@@ -38,92 +54,140 @@ const AppForm: React.FC<AppFormProps> = ({
   confirmLoading,
   width = 520,
 }) => {
-  const [form] = Form.useForm();
+  const [values, setValues] = useState<Record<string, unknown>>(createDefaultValues(fields));
+  const [errors, setErrors] = useState<Record<string, string>>({});
+
+  const defaultValues = useMemo(() => createDefaultValues(fields), [fields]);
 
   useEffect(() => {
     if (visible) {
-      if (initialValues) {
-        // Convert date strings to dayjs for DatePicker fields
-        const converted = { ...initialValues };
-        fields.forEach((f) => {
-          if (f.type === 'date' && converted[f.name] && typeof converted[f.name] === 'string') {
-            converted[f.name] = dayjs(converted[f.name] as string);
-          }
-        });
-        form.setFieldsValue(converted);
-      } else {
-        form.resetFields();
-      }
-    }
-  }, [visible, initialValues, form, fields]);
-
-  const handleOk = async () => {
-    try {
-      const values = await form.validateFields();
-      // Convert dayjs back to ISO string
-      fields.forEach((f) => {
-        if (f.type === 'date' && values[f.name]) {
-          values[f.name] = (values[f.name] as dayjs.Dayjs).format('YYYY-MM-DD');
-        }
+      setValues({
+        ...defaultValues,
+        ...(initialValues as Record<string, unknown> | undefined),
       });
-      await onSubmit(values);
-      form.resetFields();
-    } catch {
-      // validation errors handled by antd
+      setErrors({});
     }
+  }, [defaultValues, initialValues, visible]);
+
+  const updateValue = (name: string, value: unknown) => {
+    setValues((previous) => ({
+      ...previous,
+      [name]: value,
+    }));
+    setErrors((previous) => ({
+      ...previous,
+      [name]: '',
+    }));
   };
 
-  const renderField = (field: FormFieldConfig) => {
-    switch (field.type) {
-      case 'textarea':
-        return <Input.TextArea rows={3} placeholder={field.placeholder} />;
-      case 'number':
-        return <InputNumber style={{ width: '100%' }} placeholder={field.placeholder} />;
-      case 'select':
-        return (
-          <Select
-            placeholder={field.placeholder || `请选择${field.label}`}
-            options={field.options}
-            allowClear
-          />
-        );
-      case 'date':
-        return <DatePicker style={{ width: '100%' }} />;
-      case 'password':
-        return <Input.Password placeholder={field.placeholder} />;
-      default:
-        return <Input placeholder={field.placeholder || `请输入${field.label}`} />;
+  const validate = () => {
+    const nextErrors = fields.reduce<Record<string, string>>((result, field) => {
+      const value = values[field.name];
+      if (field.required && (value === '' || value === null || value === undefined)) {
+        result[field.name] = `请输入${field.label}`;
+      }
+      return result;
+    }, {});
+
+    setErrors(nextErrors);
+    return Object.keys(nextErrors).length === 0;
+  };
+
+  const handleSubmit = async () => {
+    if (!validate()) {
+      return;
     }
+
+    await onSubmit(values);
   };
 
   return (
-    <Modal
-      title={title}
+    <Dialog
       open={visible}
-      onOk={handleOk}
-      onCancel={() => {
-        form.resetFields();
-        onCancel();
-      }}
-      confirmLoading={confirmLoading}
-      width={width}
-      destroyOnClose
+      onClose={onCancel}
+      maxWidth="sm"
+      fullWidth
+      PaperProps={{ sx: { width } }}
     >
-      <Form form={form} layout="vertical" autoComplete="off">
-        {fields.map((field) => (
-          <Form.Item
-            key={field.name}
-            name={field.name}
-            label={field.label}
-            rules={
-              field.rules || (field.required ? [{ required: true, message: `请输入${field.label}` }] : [])
+      <DialogTitle>{title}</DialogTitle>
+      <DialogContent>
+        <Stack spacing={2} sx={{ pt: 1 }}>
+          {fields.map((field) => {
+            const value = values[field.name];
+
+            if (field.type === 'select') {
+              return (
+                <FormControl key={field.name} fullWidth error={Boolean(errors[field.name])}>
+                  <InputLabel>{field.label}</InputLabel>
+                  <Select
+                    label={field.label}
+                    value={(value as string | number | '') ?? ''}
+                    onChange={(event) => updateValue(field.name, event.target.value)}
+                  >
+                    {field.options?.map((option) => (
+                      <MenuItem key={option.value} value={option.value}>
+                        {option.label}
+                      </MenuItem>
+                    ))}
+                  </Select>
+                </FormControl>
+              );
             }
-          >
-            {renderField(field)}
-          </Form.Item>
-        ))}
-      </Form>
-    </Modal>
+
+            if (field.type === 'date') {
+              return (
+                <DatePicker
+                  key={field.name}
+                  label={field.label}
+                  value={value ? dayjs(String(value)) : null}
+                  onChange={(nextValue) =>
+                    updateValue(field.name, nextValue ? nextValue.format('YYYY-MM-DD') : '')
+                  }
+                  slotProps={{
+                    textField: {
+                      fullWidth: true,
+                      error: Boolean(errors[field.name]),
+                      helperText: errors[field.name] || ' ',
+                    },
+                  }}
+                />
+              );
+            }
+
+            return (
+              <TextField
+                key={field.name}
+                fullWidth
+                label={field.label}
+                type={field.type === 'password' ? 'password' : field.type === 'number' ? 'number' : 'text'}
+                multiline={field.type === 'textarea'}
+                minRows={field.type === 'textarea' ? 3 : undefined}
+                value={(value as string | number | '') ?? ''}
+                onChange={(event) =>
+                  updateValue(
+                    field.name,
+                    field.type === 'number' && event.target.value !== ''
+                      ? Number(event.target.value)
+                      : event.target.value,
+                  )
+                }
+                placeholder={field.placeholder}
+                error={Boolean(errors[field.name])}
+                helperText={errors[field.name] || ' '}
+              />
+            );
+          })}
+        </Stack>
+      </DialogContent>
+      <DialogActions sx={{ px: 3, pb: 2.5 }}>
+        <Button onClick={onCancel} color="inherit">
+          取消
+        </Button>
+        <Button onClick={handleSubmit} variant="contained" disabled={confirmLoading}>
+          {confirmLoading ? '提交中...' : '确定'}
+        </Button>
+      </DialogActions>
+    </Dialog>
   );
 };
 

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -1,0 +1,350 @@
+import { Fragment, type ReactNode, useEffect, useMemo, useState } from 'react';
+import {
+  AppBar,
+  Avatar,
+  Box,
+  Collapse,
+  Divider,
+  Drawer,
+  IconButton,
+  List,
+  ListItemButton,
+  ListItemIcon,
+  ListItemText,
+  Menu,
+  MenuItem,
+  Toolbar,
+  Tooltip,
+  Typography,
+  useMediaQuery,
+} from '@mui/material';
+import type { Theme } from '@mui/material/styles';
+import MenuOpenRoundedIcon from '@mui/icons-material/MenuOpenRounded';
+import MenuRoundedIcon from '@mui/icons-material/MenuRounded';
+import ExpandLessRoundedIcon from '@mui/icons-material/ExpandLessRounded';
+import ExpandMoreRoundedIcon from '@mui/icons-material/ExpandMoreRounded';
+import LogoutRoundedIcon from '@mui/icons-material/LogoutRounded';
+import PersonRoundedIcon from '@mui/icons-material/PersonRounded';
+import { Outlet, useLocation, useNavigate } from 'react-router-dom';
+import { useAuthStore } from '../store/auth';
+import { useAppStore } from '../store/app';
+
+const DRAWER_WIDTH = 264;
+const MINI_DRAWER_WIDTH = 88;
+
+export interface AppShellMenuItem {
+  key: string;
+  label: string;
+  icon: ReactNode;
+  children?: AppShellMenuItem[];
+}
+
+interface AppShellProps {
+  items: AppShellMenuItem[];
+  personalPath: string;
+}
+
+function matchesPath(itemKey: string, pathname: string) {
+  return pathname === itemKey || pathname.startsWith(`${itemKey}/`);
+}
+
+const AppShell: React.FC<AppShellProps> = ({ items, personalPath }) => {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { user, logout } = useAuthStore();
+  const { sidebarCollapsed, toggleSidebar } = useAppStore();
+  const isMobile = useMediaQuery((theme: Theme) => theme.breakpoints.down('lg'));
+  const [mobileOpen, setMobileOpen] = useState(false);
+  const [menuAnchorEl, setMenuAnchorEl] = useState<null | HTMLElement>(null);
+  const [expandedGroups, setExpandedGroups] = useState<Record<string, boolean>>({});
+
+  useEffect(() => {
+    const activeGroups = items.reduce<Record<string, boolean>>((accumulator, item) => {
+      if (item.children?.some((child) => matchesPath(child.key, location.pathname))) {
+        accumulator[item.key] = true;
+      }
+      return accumulator;
+    }, {});
+
+    setExpandedGroups((previous) => ({ ...previous, ...activeGroups }));
+  }, [items, location.pathname]);
+
+  const drawerWidth = sidebarCollapsed ? MINI_DRAWER_WIDTH : DRAWER_WIDTH;
+
+  const handleNavigate = (path: string) => {
+    navigate(path);
+    setMobileOpen(false);
+  };
+
+  const handleLogout = async () => {
+    await logout();
+    navigate('/login');
+  };
+
+  const brand = useMemo(
+    () => (
+      <Box
+        sx={{
+          height: 72,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: sidebarCollapsed ? 'center' : 'flex-start',
+          px: sidebarCollapsed ? 1.5 : 3,
+          gap: 1.5,
+        }}
+      >
+        <Avatar
+          sx={{
+            bgcolor: 'primary.main',
+            width: 42,
+            height: 42,
+            fontWeight: 700,
+          }}
+        >
+          医
+        </Avatar>
+        {!sidebarCollapsed && (
+          <Box>
+            <Typography variant="subtitle1" fontWeight={700}>
+              智慧医养平台
+            </Typography>
+            <Typography variant="caption" color="text.secondary">
+              Smart MedCare
+            </Typography>
+          </Box>
+        )}
+      </Box>
+    ),
+    [sidebarCollapsed],
+  );
+
+  const drawerContent = (
+    <Box sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
+      {brand}
+      <Divider />
+      <List sx={{ px: 1.5, py: 2, flex: 1 }}>
+        {items.map((item) => {
+          const selected = matchesPath(item.key, location.pathname)
+            || item.children?.some((child) => matchesPath(child.key, location.pathname));
+
+          if (!item.children?.length) {
+            return (
+              <Tooltip
+                key={item.key}
+                title={sidebarCollapsed ? item.label : ''}
+                placement="right"
+              >
+                <ListItemButton
+                  selected={selected}
+                  onClick={() => handleNavigate(item.key)}
+                  sx={{
+                    minHeight: 50,
+                    mb: 0.5,
+                    px: sidebarCollapsed ? 1.5 : 2,
+                    justifyContent: sidebarCollapsed ? 'center' : 'flex-start',
+                    borderRadius: 3,
+                  }}
+                >
+                  <ListItemIcon
+                    sx={{
+                      minWidth: 0,
+                      mr: sidebarCollapsed ? 0 : 1.5,
+                      justifyContent: 'center',
+                      color: selected ? 'primary.main' : 'inherit',
+                    }}
+                  >
+                    {item.icon}
+                  </ListItemIcon>
+                  {!sidebarCollapsed && <ListItemText primary={item.label} />}
+                </ListItemButton>
+              </Tooltip>
+            );
+          }
+
+          const expanded = expandedGroups[item.key] ?? false;
+
+          return (
+            <Fragment key={item.key}>
+              <Tooltip title={sidebarCollapsed ? item.label : ''} placement="right">
+                <ListItemButton
+                  selected={selected}
+                  onClick={() =>
+                    setExpandedGroups((previous) => ({
+                      ...previous,
+                      [item.key]: !expanded,
+                    }))
+                  }
+                  sx={{
+                    minHeight: 50,
+                    mb: 0.5,
+                    px: sidebarCollapsed ? 1.5 : 2,
+                    justifyContent: sidebarCollapsed ? 'center' : 'flex-start',
+                    borderRadius: 3,
+                  }}
+                >
+                  <ListItemIcon
+                    sx={{
+                      minWidth: 0,
+                      mr: sidebarCollapsed ? 0 : 1.5,
+                      justifyContent: 'center',
+                      color: selected ? 'primary.main' : 'inherit',
+                    }}
+                  >
+                    {item.icon}
+                  </ListItemIcon>
+                  {!sidebarCollapsed && (
+                    <>
+                      <ListItemText primary={item.label} />
+                      {expanded ? <ExpandLessRoundedIcon /> : <ExpandMoreRoundedIcon />}
+                    </>
+                  )}
+                </ListItemButton>
+              </Tooltip>
+              {!sidebarCollapsed && (
+                <Collapse in={expanded} timeout="auto" unmountOnExit>
+                  <List disablePadding sx={{ pl: 1 }}>
+                    {item.children.map((child) => (
+                      <ListItemButton
+                        key={child.key}
+                        selected={matchesPath(child.key, location.pathname)}
+                        onClick={() => handleNavigate(child.key)}
+                        sx={{ minHeight: 44, borderRadius: 3, mb: 0.5, pl: 4 }}
+                      >
+                        <ListItemIcon sx={{ minWidth: 32 }}>{child.icon}</ListItemIcon>
+                        <ListItemText primary={child.label} />
+                      </ListItemButton>
+                    ))}
+                  </List>
+                </Collapse>
+              )}
+            </Fragment>
+          );
+        })}
+      </List>
+    </Box>
+  );
+
+  return (
+    <Box sx={{ display: 'flex', minHeight: '100vh' }}>
+      <AppBar
+        color="inherit"
+        elevation={0}
+        sx={{
+          width: { lg: `calc(100% - ${drawerWidth}px)` },
+          ml: { lg: `${drawerWidth}px` },
+          borderBottom: '1px solid',
+          borderColor: 'divider',
+          backdropFilter: 'blur(18px)',
+          backgroundColor: 'rgba(255, 255, 255, 0.88)',
+        }}
+      >
+        <Toolbar sx={{ minHeight: '72px !important', px: { xs: 2, md: 3 } }}>
+          <IconButton
+            edge="start"
+            color="inherit"
+            onClick={() => (isMobile ? setMobileOpen(true) : toggleSidebar())}
+            sx={{ mr: 2 }}
+          >
+            {sidebarCollapsed ? <MenuRoundedIcon /> : <MenuOpenRoundedIcon />}
+          </IconButton>
+          <Box sx={{ flex: 1 }}>
+            <Typography variant="h6">智慧医养平台</Typography>
+            <Typography variant="body2" color="text.secondary">
+              健康管理与协同服务
+            </Typography>
+          </Box>
+          <Tooltip title="账户菜单">
+            <IconButton onClick={(event) => setMenuAnchorEl(event.currentTarget)} color="inherit">
+              <Avatar sx={{ bgcolor: 'secondary.main' }}>
+                {(user?.real_name || user?.username || 'U').slice(0, 1)}
+              </Avatar>
+            </IconButton>
+          </Tooltip>
+        </Toolbar>
+      </AppBar>
+
+      <Box component="nav" sx={{ width: { lg: drawerWidth }, flexShrink: { lg: 0 } }}>
+        <Drawer
+          variant="temporary"
+          open={mobileOpen}
+          onClose={() => setMobileOpen(false)}
+          ModalProps={{ keepMounted: true }}
+          sx={{
+            display: { xs: 'block', lg: 'none' },
+            '& .MuiDrawer-paper': {
+              width: DRAWER_WIDTH,
+              boxSizing: 'border-box',
+            },
+          }}
+        >
+          {drawerContent}
+        </Drawer>
+        <Drawer
+          variant="permanent"
+          open
+          sx={{
+            display: { xs: 'none', lg: 'block' },
+            '& .MuiDrawer-paper': {
+              width: drawerWidth,
+              boxSizing: 'border-box',
+              borderRight: '1px solid',
+              borderColor: 'divider',
+              overflowX: 'hidden',
+              transition: (theme) =>
+                theme.transitions.create('width', {
+                  duration: theme.transitions.duration.shorter,
+                }),
+            },
+          }}
+        >
+          {drawerContent}
+        </Drawer>
+      </Box>
+
+      <Box
+        component="main"
+        sx={{
+          flex: 1,
+          minWidth: 0,
+          ml: { lg: `${drawerWidth}px` },
+        }}
+      >
+        <Toolbar sx={{ minHeight: '72px !important' }} />
+        <Box sx={{ p: { xs: 2, md: 3 } }}>
+          <Outlet />
+        </Box>
+      </Box>
+
+      <Menu
+        anchorEl={menuAnchorEl}
+        open={Boolean(menuAnchorEl)}
+        onClose={() => setMenuAnchorEl(null)}
+      >
+        <MenuItem
+          onClick={() => {
+            setMenuAnchorEl(null);
+            navigate(personalPath);
+          }}
+        >
+          <ListItemIcon>
+            <PersonRoundedIcon fontSize="small" />
+          </ListItemIcon>
+          个人账户
+        </MenuItem>
+        <MenuItem
+          onClick={() => {
+            setMenuAnchorEl(null);
+            handleLogout();
+          }}
+        >
+          <ListItemIcon>
+            <LogoutRoundedIcon fontSize="small" />
+          </ListItemIcon>
+          退出登录
+        </MenuItem>
+      </Menu>
+    </Box>
+  );
+};
+
+export default AppShell;

--- a/frontend/src/components/AppTable.tsx
+++ b/frontend/src/components/AppTable.tsx
@@ -1,29 +1,92 @@
-import React from 'react';
-import { Table, Input, Space, Card } from 'antd';
-import type { ColumnsType, TablePaginationConfig } from 'antd/es/table';
+import React, { useMemo, useState } from 'react';
+import {
+  Box,
+  Button,
+  Card,
+  Checkbox,
+  CircularProgress,
+  Paper,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TablePagination,
+  TableRow,
+  TextField,
+  Typography,
+} from '@mui/material';
+import SearchRoundedIcon from '@mui/icons-material/SearchRounded';
 
-const { Search } = Input;
+export interface AppTableColumn<T> {
+  title: React.ReactNode;
+  dataIndex?: keyof T | string;
+  key?: string;
+  width?: number | string;
+  align?: 'left' | 'center' | 'right';
+  ellipsis?: boolean;
+  fixed?: 'left' | 'right';
+  render?: (value: unknown, record: T, index: number) => React.ReactNode;
+}
+
+export interface AppTablePagination {
+  current: number;
+  pageSize: number;
+  total: number;
+  showSizeChanger?: boolean;
+  showTotal?: (total: number) => string;
+}
+
+interface AppTableRowSelection<T> {
+  selectedRowKeys: React.Key[];
+  onChange: (selectedRowKeys: React.Key[], selectedRows?: T[]) => void;
+}
 
 interface AppTableProps<T> {
-  columns: ColumnsType<T>;
+  columns: AppTableColumn<T>[];
   dataSource: T[];
   loading?: boolean;
-  pagination?: TablePaginationConfig;
-  onChange?: (pagination: TablePaginationConfig) => void;
+  pagination?: AppTablePagination | false;
+  onChange?: (pagination: { current?: number; pageSize?: number }) => void;
   onSearch?: (keyword: string) => void;
   searchPlaceholder?: string;
   toolbar?: React.ReactNode;
   rowKey?: string | ((record: T) => string | number);
-  rowSelection?: object;
+  rowSelection?: AppTableRowSelection<T>;
+  emptyText?: string;
 }
 
-/**
- * Reusable table component with built-in search bar and toolbar slot.
- */
+function getValue(record: unknown, dataIndex?: string | number | symbol) {
+  if (!dataIndex || typeof dataIndex !== 'string') {
+    return undefined;
+  }
+
+  return dataIndex.split('.').reduce<unknown>((result, key) => {
+    if (result && typeof result === 'object' && key in result) {
+      return (result as Record<string, unknown>)[key];
+    }
+    return undefined;
+  }, record);
+}
+
+function getRowIdentifier<T>(record: T, rowKey: string | ((record: T) => string | number)) {
+  return typeof rowKey === 'function'
+    ? rowKey(record)
+    : (record as Record<string, string | number | undefined>)[rowKey] ?? '';
+}
+
+function renderFallbackValue(value: unknown) {
+  if (value === null || value === undefined || value === '') {
+    return '-';
+  }
+  return String(value);
+}
+
 function AppTable<T extends object>({
   columns,
   dataSource,
-  loading,
+  loading = false,
   pagination,
   onChange,
   onSearch,
@@ -31,32 +94,239 @@ function AppTable<T extends object>({
   toolbar,
   rowKey = 'id',
   rowSelection,
+  emptyText = '暂无数据',
 }: AppTableProps<T>) {
+  const [keyword, setKeyword] = useState('');
+
+  const rowIds = useMemo(
+    () => dataSource.map((record) => getRowIdentifier(record, rowKey)),
+    [dataSource, rowKey],
+  );
+
+  const selectedSet = useMemo(
+    () => new Set(rowSelection?.selectedRowKeys ?? []),
+    [rowSelection?.selectedRowKeys],
+  );
+
+  const allSelected = rowIds.length > 0 && rowIds.every((id) => selectedSet.has(id));
+  const partiallySelected = rowIds.some((id) => selectedSet.has(id)) && !allSelected;
+
+  const handleSelectAll = (checked: boolean) => {
+    if (!rowSelection) {
+      return;
+    }
+
+    rowSelection.onChange(checked ? rowIds : [], checked ? dataSource : []);
+  };
+
+  const handleToggleRow = (record: T, checked: boolean) => {
+    if (!rowSelection) {
+      return;
+    }
+
+    const id = getRowIdentifier(record, rowKey);
+    const nextKeys = checked
+      ? [...selectedSet, id]
+      : [...selectedSet].filter((item) => item !== id);
+    const selectedRows = dataSource.filter((item) =>
+      nextKeys.includes(getRowIdentifier(item, rowKey)),
+    );
+
+    rowSelection.onChange(nextKeys, selectedRows);
+  };
+
   return (
-    <Card>
-      <div style={{ marginBottom: 16, display: 'flex', justifyContent: 'space-between', flexWrap: 'wrap', gap: 8 }}>
-        <Space wrap>
+    <Card sx={{ overflow: 'hidden' }}>
+      <Stack
+        direction={{ xs: 'column', lg: 'row' }}
+        justifyContent="space-between"
+        spacing={2}
+        sx={{ mb: 2.5 }}
+      >
+        <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1.5}>
           {onSearch && (
-            <Search
+            <TextField
+              value={keyword}
+              size="small"
               placeholder={searchPlaceholder}
-              onSearch={onSearch}
-              allowClear
-              style={{ width: 280 }}
+              onChange={(event) => setKeyword(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === 'Enter') {
+                  onSearch(keyword.trim());
+                }
+              }}
+              sx={{ minWidth: { xs: '100%', sm: 280 } }}
+              InputProps={{
+                endAdornment: (
+                  <Button
+                    size="small"
+                    startIcon={<SearchRoundedIcon />}
+                    onClick={() => onSearch(keyword.trim())}
+                  >
+                    搜索
+                  </Button>
+                ),
+              }}
             />
           )}
-        </Space>
-        <Space wrap>{toolbar}</Space>
-      </div>
-      <Table<T>
-        columns={columns}
-        dataSource={dataSource}
-        loading={loading}
-        pagination={pagination}
-        onChange={(pag) => onChange?.(pag)}
-        rowKey={rowKey}
-        rowSelection={rowSelection}
-        scroll={{ x: 'max-content' }}
-      />
+        </Stack>
+        <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1.5} flexWrap="wrap">
+          {toolbar}
+        </Stack>
+      </Stack>
+
+      <Box sx={{ position: 'relative' }}>
+        {loading && (
+          <Box
+            sx={{
+              position: 'absolute',
+              inset: 0,
+              zIndex: 2,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              backgroundColor: 'rgba(255, 255, 255, 0.72)',
+            }}
+          >
+            <CircularProgress size={36} />
+          </Box>
+        )}
+
+        <TableContainer component={Paper} variant="outlined" sx={{ borderRadius: 4 }}>
+          <Table stickyHeader sx={{ minWidth: 720 }}>
+            <TableHead>
+              <TableRow>
+                {rowSelection && (
+                  <TableCell padding="checkbox" sx={{ width: 56 }}>
+                    <Checkbox
+                      checked={allSelected}
+                      indeterminate={partiallySelected}
+                      onChange={(event) => handleSelectAll(event.target.checked)}
+                    />
+                  </TableCell>
+                )}
+                {columns.map((column) => (
+                  <TableCell
+                    key={String(column.key ?? column.dataIndex ?? column.title)}
+                    align={column.align}
+                    sx={{
+                      width: column.width,
+                      minWidth: column.width,
+                      whiteSpace: 'nowrap',
+                      position: column.fixed ? 'sticky' : 'static',
+                      right: column.fixed === 'right' ? 0 : 'auto',
+                      left: column.fixed === 'left' ? 0 : 'auto',
+                      zIndex: column.fixed ? 1 : 'auto',
+                      backgroundColor: 'background.paper',
+                      fontWeight: 700,
+                    }}
+                  >
+                    {column.title}
+                  </TableCell>
+                ))}
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {dataSource.length === 0 ? (
+                <TableRow>
+                  <TableCell colSpan={columns.length + (rowSelection ? 1 : 0)} align="center">
+                    <Typography color="text.secondary" sx={{ py: 4 }}>
+                      {emptyText}
+                    </Typography>
+                  </TableCell>
+                </TableRow>
+              ) : (
+                dataSource.map((record, index) => {
+                  const id = getRowIdentifier(record, rowKey);
+
+                  return (
+                    <TableRow key={id} hover>
+                      {rowSelection && (
+                        <TableCell padding="checkbox">
+                          <Checkbox
+                            checked={selectedSet.has(id)}
+                            onChange={(event) => handleToggleRow(record, event.target.checked)}
+                          />
+                        </TableCell>
+                      )}
+                      {columns.map((column) => {
+                        const value = getValue(record, column.dataIndex);
+                        const content = column.render
+                          ? column.render(value, record, index)
+                          : renderFallbackValue(value);
+
+                        return (
+                          <TableCell
+                            key={String(column.key ?? column.dataIndex ?? column.title)}
+                            align={column.align}
+                            sx={{
+                              width: column.width,
+                              minWidth: column.width,
+                              maxWidth: column.ellipsis ? column.width : undefined,
+                              overflow: column.ellipsis ? 'hidden' : 'visible',
+                              textOverflow: column.ellipsis ? 'ellipsis' : 'clip',
+                              whiteSpace: column.ellipsis ? 'nowrap' : 'normal',
+                              position: column.fixed ? 'sticky' : 'static',
+                              right: column.fixed === 'right' ? 0 : 'auto',
+                              left: column.fixed === 'left' ? 0 : 'auto',
+                              zIndex: column.fixed ? 1 : 'auto',
+                              backgroundColor: 'background.paper',
+                            }}
+                          >
+                            {content}
+                          </TableCell>
+                        );
+                      })}
+                    </TableRow>
+                  );
+                })
+              )}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      </Box>
+
+      {pagination && (
+        <Stack
+          direction={{ xs: 'column', md: 'row' }}
+          justifyContent="space-between"
+          alignItems={{ xs: 'flex-start', md: 'center' }}
+          spacing={1}
+          sx={{ mt: 2 }}
+        >
+          <Typography variant="body2" color="text.secondary">
+            {pagination.showTotal?.(pagination.total) ?? `共 ${pagination.total} 条`}
+          </Typography>
+          <TablePagination
+            component="div"
+            count={pagination.total}
+            page={Math.max(pagination.current - 1, 0)}
+            onPageChange={(_, page) => onChange?.({ current: page + 1, pageSize: pagination.pageSize })}
+            rowsPerPage={pagination.pageSize}
+            onRowsPerPageChange={(event) =>
+              onChange?.({
+                current: 1,
+                pageSize: Number(event.target.value),
+              })
+            }
+            labelRowsPerPage="每页条数"
+            rowsPerPageOptions={
+              pagination.showSizeChanger ? [10, 20, 50, 100].map((value) => ({
+                label: `${value}`,
+                value,
+              })) : []
+            }
+            labelDisplayedRows={({ from, to, count }) => `${from}-${to} / ${count}`}
+            slotProps={{
+              select: {
+                size: 'small',
+              },
+            }}
+            showFirstButton
+            showLastButton
+          />
+        </Stack>
+      )}
     </Card>
   );
 }

--- a/frontend/src/components/AppTable.tsx
+++ b/frontend/src/components/AppTable.tsx
@@ -30,6 +30,8 @@ export interface AppTableColumn<T> {
   render?: (value: unknown, record: T, index: number) => React.ReactNode;
 }
 
+export type ColumnsType<T> = AppTableColumn<T>[];
+
 export interface AppTablePagination {
   current: number;
   pageSize: number;

--- a/frontend/src/components/AppTable.tsx
+++ b/frontend/src/components/AppTable.tsx
@@ -20,14 +20,14 @@ import {
 import SearchRoundedIcon from '@mui/icons-material/SearchRounded';
 
 export interface AppTableColumn<T> {
-  title: React.ReactNode;
+  title?: React.ReactNode | ((props: any) => React.ReactNode);
   dataIndex?: keyof T | string;
   key?: string;
   width?: number | string;
   align?: 'left' | 'center' | 'right';
   ellipsis?: boolean;
   fixed?: 'left' | 'right';
-  render?: (value: unknown, record: T, index: number) => React.ReactNode;
+  render?: (value: any, record: T, index: number) => React.ReactNode;
 }
 
 export interface AppTablePagination {
@@ -81,6 +81,13 @@ function renderFallbackValue(value: unknown) {
     return '-';
   }
   return String(value);
+}
+
+function resolveTitle(title: AppTableColumn<object>['title']) {
+  if (typeof title === 'function') {
+    return title({});
+  }
+  return title ?? '';
 }
 
 function AppTable<T extends object>({
@@ -221,7 +228,7 @@ function AppTable<T extends object>({
                       fontWeight: 700,
                     }}
                   >
-                    {column.title}
+                    {resolveTitle(column.title as AppTableColumn<object>['title'])}
                   </TableCell>
                 ))}
               </TableRow>

--- a/frontend/src/components/StatCard.tsx
+++ b/frontend/src/components/StatCard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Card, Statistic } from 'antd';
+import { Avatar, Card, Skeleton, Stack, Typography } from '@mui/material';
 import type { ReactNode } from 'react';
 
 interface StatCardProps {
@@ -23,22 +23,38 @@ const StatCard: React.FC<StatCardProps> = ({
   loading,
 }) => {
   return (
-    <Card hoverable loading={loading}>
-      <div style={{ display: 'flex', alignItems: 'center', gap: 16 }}>
+    <Card sx={{ height: '100%' }}>
+      <Stack direction="row" spacing={2} alignItems="center">
         {icon && (
-          <div
-            style={{
-              fontSize: 32,
+          <Avatar
+            sx={{
+              width: 56,
+              height: 56,
+              bgcolor: `${color || '#1677ff'}18`,
               color: color || '#1677ff',
-              display: 'flex',
-              alignItems: 'center',
             }}
           >
             {icon}
-          </div>
+          </Avatar>
         )}
-        <Statistic title={title} value={value} suffix={suffix} />
-      </div>
+        <div>
+          <Typography variant="body2" color="text.secondary" gutterBottom>
+            {title}
+          </Typography>
+          {loading ? (
+            <Skeleton variant="text" width={96} height={42} />
+          ) : (
+            <Typography variant="h4">
+              {value}
+              {suffix ? (
+                <Typography component="span" variant="h6" color="text.secondary" sx={{ ml: 0.5 }}>
+                  {suffix}
+                </Typography>
+              ) : null}
+            </Typography>
+          )}
+        </div>
+      </Stack>
     </Card>
   );
 };

--- a/frontend/src/components/ToastProvider.tsx
+++ b/frontend/src/components/ToastProvider.tsx
@@ -33,7 +33,7 @@ const ToastProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
 
   const alert = useMemo(() => {
     if (!current) {
-      return null;
+      return undefined;
     }
 
     return (

--- a/frontend/src/components/ToastProvider.tsx
+++ b/frontend/src/components/ToastProvider.tsx
@@ -1,0 +1,61 @@
+import { type ReactNode, useEffect, useMemo, useState } from 'react';
+import { Alert, Snackbar } from '@mui/material';
+import { subscribeMessage } from '../utils/message';
+
+interface ToastItem {
+  id: number;
+  type: 'success' | 'error' | 'warning' | 'info';
+  content: string;
+  duration: number;
+}
+
+const ToastProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
+  const [queue, setQueue] = useState<ToastItem[]>([]);
+  const [current, setCurrent] = useState<ToastItem | null>(null);
+
+  useEffect(() => {
+    return subscribeMessage((event) => {
+      setQueue((previous) => [...previous, event]);
+    });
+  }, []);
+
+  useEffect(() => {
+    if (!current && queue.length > 0) {
+      const [next, ...rest] = queue;
+      setCurrent(next);
+      setQueue(rest);
+    }
+  }, [current, queue]);
+
+  const handleClose = () => {
+    setCurrent(null);
+  };
+
+  const alert = useMemo(() => {
+    if (!current) {
+      return null;
+    }
+
+    return (
+      <Alert variant="filled" severity={current.type} onClose={handleClose} sx={{ width: '100%' }}>
+        {current.content}
+      </Alert>
+    );
+  }, [current]);
+
+  return (
+    <>
+      {children}
+      <Snackbar
+        open={Boolean(current)}
+        autoHideDuration={current?.duration ?? 3000}
+        onClose={handleClose}
+        anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
+      >
+        {alert}
+      </Snackbar>
+    </>
+  );
+};
+
+export default ToastProvider;

--- a/frontend/src/components/UploadFile.tsx
+++ b/frontend/src/components/UploadFile.tsx
@@ -1,8 +1,8 @@
 import React, { useState } from 'react';
-import { Upload, Button, message } from 'antd';
-import { UploadOutlined } from '@ant-design/icons';
-import type { UploadFile as AntUploadFile, UploadChangeParam } from 'antd/es/upload';
-import { getToken } from '../utils/storage';
+import { Button } from '@mui/material';
+import UploadRoundedIcon from '@mui/icons-material/UploadRounded';
+import http from '../api/http';
+import { message } from '../utils/message';
 
 interface UploadFileProps {
   category?: string;
@@ -22,39 +22,48 @@ const UploadFile: React.FC<UploadFileProps> = ({
   accept,
   maxCount = 1,
 }) => {
-  const [fileList, setFileList] = useState<AntUploadFile[]>([]);
+  const [uploading, setUploading] = useState(false);
 
-  const handleChange = (info: UploadChangeParam) => {
-    setFileList(info.fileList);
-    if (info.file.status === 'done') {
-      const res = info.file.response;
-      if (res?.code === 0) {
-        message.success('上传成功');
-        onSuccess?.(res.data);
-      } else {
-        message.error(res?.message || '上传失败');
-      }
-    } else if (info.file.status === 'error') {
-      message.error('上传失败');
+  const handleFileChange = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+
+    if (!file) {
+      return;
+    }
+
+    const formData = new FormData();
+    formData.append('file', file);
+    if (category) {
+      formData.append('category', category);
+    }
+    if (elderId) {
+      formData.append('elder_id', String(elderId));
+    }
+
+    setUploading(true);
+
+    try {
+      const response = await http.post('/files/upload', formData, {
+        headers: {
+          'Content-Type': 'multipart/form-data',
+        },
+      });
+
+      message.success('上传成功');
+      onSuccess?.(response.data);
+    } catch (error) {
+      message.error(error instanceof Error ? error.message : '上传失败');
+    } finally {
+      setUploading(false);
+      event.target.value = '';
     }
   };
 
-  const data: Record<string, string> = {};
-  if (category) data.category = category;
-  if (elderId) data.elder_id = String(elderId);
-
   return (
-    <Upload
-      action="/api/v1/files/upload"
-      headers={{ Authorization: `Bearer ${getToken() || ''}` }}
-      data={data}
-      fileList={fileList}
-      onChange={handleChange}
-      accept={accept}
-      maxCount={maxCount}
-    >
-      <Button icon={<UploadOutlined />}>上传文件</Button>
-    </Upload>
+    <Button component="label" variant="outlined" startIcon={<UploadRoundedIcon />} disabled={uploading}>
+      {uploading ? '上传中...' : '上传文件'}
+      <input hidden type="file" accept={accept} multiple={maxCount > 1} onChange={handleFileChange} />
+    </Button>
   );
 };
 

--- a/frontend/src/components/UploadFile.tsx
+++ b/frontend/src/components/UploadFile.tsx
@@ -8,8 +8,10 @@ interface UploadFileProps {
   category?: string;
   elderId?: number;
   onSuccess?: (fileInfo: { file_id: number; file_name: string; url: string }) => void;
+  onUpload?: (file: File) => Promise<void> | void;
   accept?: string;
   maxCount?: number;
+  buttonText?: string;
 }
 
 /**
@@ -19,8 +21,10 @@ const UploadFile: React.FC<UploadFileProps> = ({
   category,
   elderId,
   onSuccess,
+  onUpload,
   accept,
   maxCount = 1,
+  buttonText = '上传文件',
 }) => {
   const [uploading, setUploading] = useState(false);
 
@@ -43,14 +47,18 @@ const UploadFile: React.FC<UploadFileProps> = ({
     setUploading(true);
 
     try {
-      const response = await http.post('/files/upload', formData, {
-        headers: {
-          'Content-Type': 'multipart/form-data',
-        },
-      });
+      if (onUpload) {
+        await onUpload(file);
+      } else {
+        const response = await http.post('/files/upload', formData, {
+          headers: {
+            'Content-Type': 'multipart/form-data',
+          },
+        });
 
-      message.success('上传成功');
-      onSuccess?.(response.data);
+        message.success('上传成功');
+        onSuccess?.(response.data);
+      }
     } catch (error) {
       message.error(error instanceof Error ? error.message : '上传失败');
     } finally {
@@ -61,7 +69,7 @@ const UploadFile: React.FC<UploadFileProps> = ({
 
   return (
     <Button component="label" variant="outlined" startIcon={<UploadRoundedIcon />} disabled={uploading}>
-      {uploading ? '上传中...' : '上传文件'}
+      {uploading ? '处理中...' : buttonText}
       <input hidden type="file" accept={accept} multiple={maxCount > 1} onChange={handleFileChange} />
     </Button>
   );

--- a/frontend/src/hooks/useTable.ts
+++ b/frontend/src/hooks/useTable.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
-import { message } from 'antd';
 import type { PaginatedData, ApiResponse } from '../types/common';
+import { message } from '../utils/message';
 
 interface UseTableOptions<TQuery> {
   defaultPageSize?: number;

--- a/frontend/src/layouts/BasicLayout.tsx
+++ b/frontend/src/layouts/BasicLayout.tsx
@@ -7,7 +7,7 @@ import MedicalInformationRoundedIcon from '@mui/icons-material/MedicalInformatio
 import MedicationRoundedIcon from '@mui/icons-material/MedicationRounded';
 import NotificationsActiveRoundedIcon from '@mui/icons-material/NotificationsActiveRounded';
 import PersonRoundedIcon from '@mui/icons-material/PersonRounded';
-import StethoscopeRoundedIcon from '@mui/icons-material/StethoscopeRounded';
+import MedicalServicesRoundedIcon from '@mui/icons-material/MedicalServicesRounded';
 import TimelineRoundedIcon from '@mui/icons-material/TimelineRounded';
 import AppShell, { type AppShellMenuItem } from '../components/AppShell';
 import { usePermission } from '../hooks/usePermission';
@@ -75,7 +75,7 @@ const BasicLayout: React.FC = () => {
     if (hasAnyPermission(['user:manage'])) {
       items.push({
         key: '/doctors',
-        icon: <StethoscopeRoundedIcon />,
+        icon: <MedicalServicesRoundedIcon />,
         label: '医生管理',
       });
       items.push({

--- a/frontend/src/layouts/BasicLayout.tsx
+++ b/frontend/src/layouts/BasicLayout.tsx
@@ -1,41 +1,25 @@
 import React, { useMemo } from 'react';
-import { Outlet, useNavigate, useLocation } from 'react-router-dom';
-import { Layout, Menu, Button, Dropdown, theme } from 'antd';
-import {
-  DashboardOutlined,
-  TeamOutlined,
-  AlertOutlined,
-  ScheduleOutlined,
-  MedicineBoxOutlined,
-  FileSearchOutlined,
-  UserOutlined,
-  HeartOutlined,
-  LogoutOutlined,
-  MenuFoldOutlined,
-  MenuUnfoldOutlined,
-} from '@ant-design/icons';
-import type { MenuProps } from 'antd';
-import { useAuthStore } from '../store/auth';
-import { useAppStore } from '../store/app';
+import DashboardRoundedIcon from '@mui/icons-material/DashboardRounded';
+import ElderlyRoundedIcon from '@mui/icons-material/ElderlyRounded';
+import FamilyRestroomRoundedIcon from '@mui/icons-material/FamilyRestroomRounded';
+import HealingRoundedIcon from '@mui/icons-material/HealingRounded';
+import MedicalInformationRoundedIcon from '@mui/icons-material/MedicalInformationRounded';
+import MedicationRoundedIcon from '@mui/icons-material/MedicationRounded';
+import NotificationsActiveRoundedIcon from '@mui/icons-material/NotificationsActiveRounded';
+import PersonRoundedIcon from '@mui/icons-material/PersonRounded';
+import StethoscopeRoundedIcon from '@mui/icons-material/StethoscopeRounded';
+import TimelineRoundedIcon from '@mui/icons-material/TimelineRounded';
+import AppShell, { type AppShellMenuItem } from '../components/AppShell';
 import { usePermission } from '../hooks/usePermission';
 
-const { Header, Sider, Content } = Layout;
-
-type MenuItem = Required<MenuProps>['items'][number];
-
 const BasicLayout: React.FC = () => {
-  const navigate = useNavigate();
-  const location = useLocation();
-  const { user, logout } = useAuthStore();
-  const { sidebarCollapsed, toggleSidebar } = useAppStore();
   const { hasAnyPermission } = usePermission();
-  const { token: themeToken } = theme.useToken();
 
-  const menuItems = useMemo<MenuItem[]>(() => {
-    const items: MenuItem[] = [
+  const menuItems = useMemo<AppShellMenuItem[]>(() => {
+    const items: AppShellMenuItem[] = [
       {
         key: '/dashboard',
-        icon: <DashboardOutlined />,
+        icon: <DashboardRoundedIcon />,
         label: '工作台',
       },
     ];
@@ -43,11 +27,11 @@ const BasicLayout: React.FC = () => {
     if (hasAnyPermission(['elder:read', 'elder:create'])) {
       items.push({
         key: '/elders',
-        icon: <TeamOutlined />,
+        icon: <ElderlyRoundedIcon />,
         label: '老人管理',
         children: [
-          { key: '/elders', label: '老人列表' },
-          { key: '/elders/archive', label: '老人档案' },
+          { key: '/elders', label: '老人列表', icon: <ElderlyRoundedIcon fontSize="small" /> },
+          { key: '/elders/archive', label: '老人档案', icon: <MedicalInformationRoundedIcon fontSize="small" /> },
         ],
       });
     }
@@ -55,7 +39,7 @@ const BasicLayout: React.FC = () => {
     if (hasAnyPermission(['alert:read', 'alert:update'])) {
       items.push({
         key: '/alerts',
-        icon: <AlertOutlined />,
+        icon: <NotificationsActiveRoundedIcon />,
         label: '风险预警',
       });
     }
@@ -63,11 +47,11 @@ const BasicLayout: React.FC = () => {
     if (hasAnyPermission(['followup:create', 'followup:update'])) {
       items.push({
         key: '/followups',
-        icon: <ScheduleOutlined />,
+        icon: <TimelineRoundedIcon />,
         label: '随访管理',
         children: [
-          { key: '/followups/plans', label: '随访计划' },
-          { key: '/followups/records', label: '随访记录' },
+          { key: '/followups/plans', label: '随访计划', icon: <TimelineRoundedIcon fontSize="small" /> },
+          { key: '/followups/records', label: '随访记录', icon: <HealingRoundedIcon fontSize="small" /> },
         ],
       });
     }
@@ -75,7 +59,7 @@ const BasicLayout: React.FC = () => {
     if (hasAnyPermission(['intervention:create'])) {
       items.push({
         key: '/interventions',
-        icon: <MedicineBoxOutlined />,
+        icon: <MedicationRoundedIcon />,
         label: '干预记录',
       });
     }
@@ -83,7 +67,7 @@ const BasicLayout: React.FC = () => {
     if (hasAnyPermission(['assessment:read', 'assessment:create'])) {
       items.push({
         key: '/assessments',
-        icon: <FileSearchOutlined />,
+        icon: <MedicalInformationRoundedIcon />,
         label: '健康评估',
       });
     }
@@ -91,141 +75,26 @@ const BasicLayout: React.FC = () => {
     if (hasAnyPermission(['user:manage'])) {
       items.push({
         key: '/doctors',
-        icon: <MedicineBoxOutlined />,
+        icon: <StethoscopeRoundedIcon />,
         label: '医生管理',
       });
       items.push({
         key: '/family-members',
-        icon: <HeartOutlined />,
+        icon: <FamilyRestroomRoundedIcon />,
         label: '家属管理',
       });
     }
 
     items.push({
       key: '/accounts/personal',
-      icon: <UserOutlined />,
+      icon: <PersonRoundedIcon />,
       label: '个人账户',
     });
 
     return items;
   }, [hasAnyPermission]);
 
-  // Determine selected and open keys from current path
-  const selectedKeys = useMemo(() => {
-    const path = location.pathname;
-    // Match exact path first, then try parent paths
-    if (path.startsWith('/elders') && !path.includes('/archive')) return ['/elders'];
-    if (path.includes('/archive')) return ['/elders/archive'];
-    return [path];
-  }, [location.pathname]);
-
-  const openKeys = useMemo(() => {
-    const path = location.pathname;
-    if (path.startsWith('/elders')) return ['/elders'];
-    if (path.startsWith('/followups')) return ['/followups'];
-    return [];
-  }, [location.pathname]);
-
-  const handleMenuClick: MenuProps['onClick'] = ({ key }) => {
-    navigate(key);
-  };
-
-  const handleLogout = async () => {
-    await logout();
-    navigate('/login');
-  };
-
-  const userMenuItems: MenuProps['items'] = [
-    {
-      key: 'personal',
-      icon: <UserOutlined />,
-      label: '个人账户',
-      onClick: () => navigate('/accounts/personal'),
-    },
-    { type: 'divider' },
-    {
-      key: 'logout',
-      icon: <LogoutOutlined />,
-      label: '退出登录',
-      onClick: handleLogout,
-    },
-  ];
-
-  return (
-    <Layout style={{ minHeight: '100vh' }}>
-      <Sider
-        trigger={null}
-        collapsible
-        collapsed={sidebarCollapsed}
-        width={240}
-        style={{
-          overflow: 'auto',
-          height: '100vh',
-          position: 'fixed',
-          left: 0,
-          top: 0,
-          bottom: 0,
-          background: themeToken.colorBgContainer,
-          borderRight: `1px solid ${themeToken.colorBorderSecondary}`,
-        }}
-      >
-        <div
-          style={{
-            height: 64,
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            fontWeight: 700,
-            fontSize: sidebarCollapsed ? 14 : 16,
-            color: themeToken.colorPrimary,
-            borderBottom: `1px solid ${themeToken.colorBorderSecondary}`,
-            padding: '0 16px',
-            whiteSpace: 'nowrap',
-            overflow: 'hidden',
-          }}
-        >
-          {sidebarCollapsed ? '医养' : '智慧医养平台'}
-        </div>
-        <Menu
-          mode="inline"
-          selectedKeys={selectedKeys}
-          defaultOpenKeys={openKeys}
-          items={menuItems}
-          onClick={handleMenuClick}
-          style={{ border: 'none' }}
-        />
-      </Sider>
-      <Layout style={{ marginLeft: sidebarCollapsed ? 80 : 240, transition: 'margin-left 0.2s' }}>
-        <Header
-          style={{
-            padding: '0 24px',
-            background: themeToken.colorBgContainer,
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'space-between',
-            borderBottom: `1px solid ${themeToken.colorBorderSecondary}`,
-            position: 'sticky',
-            top: 0,
-            zIndex: 10,
-          }}
-        >
-          <Button
-            type="text"
-            icon={sidebarCollapsed ? <MenuUnfoldOutlined /> : <MenuFoldOutlined />}
-            onClick={toggleSidebar}
-          />
-          <Dropdown menu={{ items: userMenuItems }} placement="bottomRight">
-            <Button type="text" icon={<UserOutlined />}>
-              {user?.real_name || user?.username || '用户'}
-            </Button>
-          </Dropdown>
-        </Header>
-        <Content style={{ margin: 24, minHeight: 280 }}>
-          <Outlet />
-        </Content>
-      </Layout>
-    </Layout>
-  );
+  return <AppShell items={menuItems} personalPath="/accounts/personal" />;
 };
 
 export default BasicLayout;

--- a/frontend/src/layouts/BlankLayout.tsx
+++ b/frontend/src/layouts/BlankLayout.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Box } from '@mui/material';
 import { Outlet } from 'react-router-dom';
 
 /**
@@ -6,17 +7,19 @@ import { Outlet } from 'react-router-dom';
  */
 const BlankLayout: React.FC = () => {
   return (
-    <div
-      style={{
+    <Box
+      sx={{
         minHeight: '100vh',
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'center',
-        background: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
+        px: 2,
+        background:
+          'radial-gradient(circle at top left, rgba(31, 111, 235, 0.24), transparent 35%), linear-gradient(135deg, #f7fbff 0%, #e5f4f2 52%, #d9e7ff 100%)',
       }}
     >
       <Outlet />
-    </div>
+    </Box>
   );
 };
 

--- a/frontend/src/layouts/ElderLayout.tsx
+++ b/frontend/src/layouts/ElderLayout.tsx
@@ -1,152 +1,31 @@
 import React, { useMemo } from 'react';
-import { Outlet, useNavigate, useLocation } from 'react-router-dom';
-import { Layout, Menu, Button, Dropdown, theme } from 'antd';
-import {
-  HomeOutlined,
-  UsergroupAddOutlined,
-  UserOutlined,
-  LogoutOutlined,
-  MenuFoldOutlined,
-  MenuUnfoldOutlined,
-} from '@ant-design/icons';
-import type { MenuProps } from 'antd';
-import { useAuthStore } from '../store/auth';
-import { useAppStore } from '../store/app';
-
-const { Header, Sider, Content } = Layout;
-
-type MenuItem = Required<MenuProps>['items'][number];
+import GroupAddRoundedIcon from '@mui/icons-material/GroupAddRounded';
+import HomeRoundedIcon from '@mui/icons-material/HomeRounded';
+import PersonRoundedIcon from '@mui/icons-material/PersonRounded';
+import AppShell, { type AppShellMenuItem } from '../components/AppShell';
 
 const ElderLayout: React.FC = () => {
-  const navigate = useNavigate();
-  const location = useLocation();
-  const { user, logout } = useAuthStore();
-  const { sidebarCollapsed, toggleSidebar } = useAppStore();
-  const { token: themeToken } = theme.useToken();
-
-  const menuItems = useMemo<MenuItem[]>(() => {
+  const menuItems = useMemo<AppShellMenuItem[]>(() => {
     return [
       {
         key: '/elder',
-        icon: <HomeOutlined />,
+        icon: <HomeRoundedIcon />,
         label: '首页',
       },
       {
         key: '/elder/invite',
-        icon: <UsergroupAddOutlined />,
+        icon: <GroupAddRoundedIcon />,
         label: '邀请家属',
       },
       {
         key: '/elder/personal',
-        icon: <UserOutlined />,
+        icon: <PersonRoundedIcon />,
         label: '个人账户',
       },
     ];
   }, []);
 
-  const selectedKeys = useMemo(() => {
-    return [location.pathname];
-  }, [location.pathname]);
-
-  const handleMenuClick: MenuProps['onClick'] = ({ key }) => {
-    navigate(key);
-  };
-
-  const handleLogout = async () => {
-    await logout();
-    navigate('/login');
-  };
-
-  const userMenuItems: MenuProps['items'] = [
-    {
-      key: 'personal',
-      icon: <UserOutlined />,
-      label: '个人账户',
-      onClick: () => navigate('/elder/personal'),
-    },
-    { type: 'divider' },
-    {
-      key: 'logout',
-      icon: <LogoutOutlined />,
-      label: '退出登录',
-      onClick: handleLogout,
-    },
-  ];
-
-  return (
-    <Layout style={{ minHeight: '100vh' }}>
-      <Sider
-        trigger={null}
-        collapsible
-        collapsed={sidebarCollapsed}
-        width={240}
-        style={{
-          overflow: 'auto',
-          height: '100vh',
-          position: 'fixed',
-          left: 0,
-          top: 0,
-          bottom: 0,
-          background: themeToken.colorBgContainer,
-          borderRight: `1px solid ${themeToken.colorBorderSecondary}`,
-        }}
-      >
-        <div
-          style={{
-            height: 64,
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            fontWeight: 700,
-            fontSize: sidebarCollapsed ? 14 : 16,
-            color: themeToken.colorPrimary,
-            borderBottom: `1px solid ${themeToken.colorBorderSecondary}`,
-            padding: '0 16px',
-            whiteSpace: 'nowrap',
-            overflow: 'hidden',
-          }}
-        >
-          {sidebarCollapsed ? '医养' : '智慧医养平台'}
-        </div>
-        <Menu
-          mode="inline"
-          selectedKeys={selectedKeys}
-          items={menuItems}
-          onClick={handleMenuClick}
-          style={{ border: 'none' }}
-        />
-      </Sider>
-      <Layout style={{ marginLeft: sidebarCollapsed ? 80 : 240, transition: 'margin-left 0.2s' }}>
-        <Header
-          style={{
-            padding: '0 24px',
-            background: themeToken.colorBgContainer,
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'space-between',
-            borderBottom: `1px solid ${themeToken.colorBorderSecondary}`,
-            position: 'sticky',
-            top: 0,
-            zIndex: 10,
-          }}
-        >
-          <Button
-            type="text"
-            icon={sidebarCollapsed ? <MenuUnfoldOutlined /> : <MenuFoldOutlined />}
-            onClick={toggleSidebar}
-          />
-          <Dropdown menu={{ items: userMenuItems }} placement="bottomRight">
-            <Button type="text" icon={<UserOutlined />}>
-              {user?.real_name || user?.username || '用户'}
-            </Button>
-          </Dropdown>
-        </Header>
-        <Content style={{ margin: 24, minHeight: 280 }}>
-          <Outlet />
-        </Content>
-      </Layout>
-    </Layout>
-  );
+  return <AppShell items={menuItems} personalPath="/elder/personal" />;
 };
 
 export default ElderLayout;

--- a/frontend/src/layouts/FamilyLayout.tsx
+++ b/frontend/src/layouts/FamilyLayout.tsx
@@ -1,150 +1,29 @@
 import React, { useMemo } from 'react';
-import { Outlet, useNavigate, useLocation } from 'react-router-dom';
-import { Layout, Menu, Button, Dropdown, theme } from 'antd';
-import {
-  HomeOutlined,
-  HeartOutlined,
-  UserOutlined,
-  LogoutOutlined,
-  MenuFoldOutlined,
-  MenuUnfoldOutlined,
-} from '@ant-design/icons';
-import type { MenuProps } from 'antd';
-import { useAuthStore } from '../store/auth';
-import { useAppStore } from '../store/app';
-
-const { Header, Sider, Content } = Layout;
-
-type MenuItem = Required<MenuProps>['items'][number];
+import FavoriteRoundedIcon from '@mui/icons-material/FavoriteRounded';
+import HomeRoundedIcon from '@mui/icons-material/HomeRounded';
+import PersonRoundedIcon from '@mui/icons-material/PersonRounded';
+import AppShell, { type AppShellMenuItem } from '../components/AppShell';
 
 const FamilyLayout: React.FC = () => {
-  const navigate = useNavigate();
-  const location = useLocation();
-  const { user, logout } = useAuthStore();
-  const { sidebarCollapsed, toggleSidebar } = useAppStore();
-  const { token: themeToken } = theme.useToken();
-
-  const menuItems = useMemo<MenuItem[]>(() => [
+  const menuItems = useMemo<AppShellMenuItem[]>(() => [
     {
       key: '/family',
-      icon: <HomeOutlined />,
+      icon: <HomeRoundedIcon />,
       label: '首页',
     },
     {
       key: '/family/elder',
-      icon: <HeartOutlined />,
+      icon: <FavoriteRoundedIcon />,
       label: '老人健康',
     },
     {
       key: '/family/personal',
-      icon: <UserOutlined />,
+      icon: <PersonRoundedIcon />,
       label: '个人账户',
     },
   ], []);
 
-  const selectedKeys = useMemo(() => {
-    return [location.pathname];
-  }, [location.pathname]);
-
-  const handleMenuClick: MenuProps['onClick'] = ({ key }) => {
-    navigate(key);
-  };
-
-  const handleLogout = async () => {
-    await logout();
-    navigate('/login');
-  };
-
-  const userMenuItems: MenuProps['items'] = [
-    {
-      key: 'personal',
-      icon: <UserOutlined />,
-      label: '个人账户',
-      onClick: () => navigate('/family/personal'),
-    },
-    { type: 'divider' },
-    {
-      key: 'logout',
-      icon: <LogoutOutlined />,
-      label: '退出登录',
-      onClick: handleLogout,
-    },
-  ];
-
-  return (
-    <Layout style={{ minHeight: '100vh' }}>
-      <Sider
-        trigger={null}
-        collapsible
-        collapsed={sidebarCollapsed}
-        width={240}
-        style={{
-          overflow: 'auto',
-          height: '100vh',
-          position: 'fixed',
-          left: 0,
-          top: 0,
-          bottom: 0,
-          background: themeToken.colorBgContainer,
-          borderRight: `1px solid ${themeToken.colorBorderSecondary}`,
-        }}
-      >
-        <div
-          style={{
-            height: 64,
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            fontWeight: 700,
-            fontSize: sidebarCollapsed ? 14 : 16,
-            color: themeToken.colorPrimary,
-            borderBottom: `1px solid ${themeToken.colorBorderSecondary}`,
-            padding: '0 16px',
-            whiteSpace: 'nowrap',
-            overflow: 'hidden',
-          }}
-        >
-          {sidebarCollapsed ? '医养' : '智慧医养平台'}
-        </div>
-        <Menu
-          mode="inline"
-          selectedKeys={selectedKeys}
-          items={menuItems}
-          onClick={handleMenuClick}
-          style={{ border: 'none' }}
-        />
-      </Sider>
-      <Layout style={{ marginLeft: sidebarCollapsed ? 80 : 240, transition: 'margin-left 0.2s' }}>
-        <Header
-          style={{
-            padding: '0 24px',
-            background: themeToken.colorBgContainer,
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'space-between',
-            borderBottom: `1px solid ${themeToken.colorBorderSecondary}`,
-            position: 'sticky',
-            top: 0,
-            zIndex: 10,
-          }}
-        >
-          <Button
-            type="text"
-            icon={sidebarCollapsed ? <MenuUnfoldOutlined /> : <MenuFoldOutlined />}
-            onClick={toggleSidebar}
-          />
-          <Dropdown menu={{ items: userMenuItems }} placement="bottomRight">
-            <Button type="text" icon={<UserOutlined />}>
-              {user?.real_name || user?.username || '用户'}
-            </Button>
-          </Dropdown>
-        </Header>
-        <Content style={{ margin: 24, minHeight: 280 }}>
-          <Outlet />
-        </Content>
-      </Layout>
-    </Layout>
-  );
+  return <AppShell items={menuItems} personalPath="/family/personal" />;
 };
 
 export default FamilyLayout;

--- a/frontend/src/pages/accounts/ElderAccountPage.tsx
+++ b/frontend/src/pages/accounts/ElderAccountPage.tsx
@@ -1,12 +1,14 @@
 import React, { useCallback } from 'react';
-import { Button, Tag, Space, Popconfirm, message } from 'antd';
-import type { ColumnsType } from 'antd/es/table';
-import AppTable from '../../components/AppTable';
+import { Button, Chip, Stack } from '@mui/material';
+import RestartAltRoundedIcon from '@mui/icons-material/RestartAltRounded';
+import PowerSettingsNewRoundedIcon from '@mui/icons-material/PowerSettingsNewRounded';
+import AppTable, { type AppTableColumn } from '../../components/AppTable';
 import PermissionGuard from '../../components/PermissionGuard';
 import { useTable } from '../../hooks/useTable';
 import { getElders, resetElderPassword, updateElderAccountStatus } from '../../api/elders';
 import { formatGender } from '../../utils/formatter';
 import type { Elder, ElderListQuery } from '../../types/elder';
+import { message } from '../../utils/message';
 
 const ElderAccountPage: React.FC = () => {
   const fetchFn = useCallback(
@@ -18,6 +20,10 @@ const ElderAccountPage: React.FC = () => {
     useTable<Elder, ElderListQuery>(fetchFn);
 
   const handleResetPassword = async (elderId: number) => {
+    if (!window.confirm('确定重置密码？')) {
+      return;
+    }
+
     try {
       await resetElderPassword(elderId);
       message.success('密码重置成功');
@@ -28,6 +34,10 @@ const ElderAccountPage: React.FC = () => {
 
   const handleToggleStatus = async (elderId: number, currentStatus: string) => {
     const newStatus = currentStatus === 'active' ? 'disabled' : 'active';
+    if (!window.confirm(`确定${newStatus === 'active' ? '启用' : '禁用'}该账户？`)) {
+      return;
+    }
+
     try {
       await updateElderAccountStatus(elderId, newStatus);
       message.success(newStatus === 'active' ? '已启用' : '已禁用');
@@ -37,20 +47,31 @@ const ElderAccountPage: React.FC = () => {
     }
   };
 
-  const columns: ColumnsType<Elder> = [
+  const columns: AppTableColumn<Elder>[] = [
     { title: '姓名', dataIndex: 'name', width: 100 },
-    { title: '性别', dataIndex: 'gender', width: 80, render: formatGender },
+    {
+      title: '性别',
+      dataIndex: 'gender',
+      width: 80,
+      render: (value) => formatGender(value as string | null | undefined),
+    },
     { title: '联系电话', dataIndex: 'phone', width: 130 },
     { title: '身份证号', dataIndex: 'id_card', width: 180 },
     {
       title: '账户状态',
       dataIndex: 'account_status',
       width: 100,
-      render: (status: string) => (
-        <Tag color={status === 'active' ? 'green' : 'red'}>
-          {status === 'active' ? '正常' : '已禁用'}
-        </Tag>
-      ),
+      render: (value) => {
+        const status = String(value);
+        return (
+          <Chip
+            size="small"
+            color={status === 'active' ? 'success' : 'error'}
+            variant="outlined"
+            label={status === 'active' ? '正常' : '已禁用'}
+          />
+        );
+      },
     },
     {
       title: '操作',
@@ -58,28 +79,27 @@ const ElderAccountPage: React.FC = () => {
       width: 220,
       fixed: 'right',
       render: (_, record) => (
-        <Space>
+        <Stack direction="row" spacing={0.5}>
           <PermissionGuard permission="elder:update">
-            <Popconfirm
-              title="确定重置密码？"
-              onConfirm={() => handleResetPassword(record.id)}
+            <Button
+              size="small"
+              variant="text"
+              startIcon={<RestartAltRoundedIcon fontSize="small" />}
+              onClick={() => handleResetPassword(record.id)}
             >
-              <Button type="link" size="small">重置密码</Button>
-            </Popconfirm>
-            <Popconfirm
-              title={`确定${record.account_status === 'active' ? '禁用' : '启用'}该账户？`}
-              onConfirm={() => handleToggleStatus(record.id, record.account_status)}
+              重置密码
+            </Button>
+            <Button
+              size="small"
+              variant="text"
+              color={record.account_status === 'active' ? 'error' : 'primary'}
+              startIcon={<PowerSettingsNewRoundedIcon fontSize="small" />}
+              onClick={() => handleToggleStatus(record.id, record.account_status)}
             >
-              <Button
-                type="link"
-                size="small"
-                danger={record.account_status === 'active'}
-              >
-                {record.account_status === 'active' ? '禁用' : '启用'}
-              </Button>
-            </Popconfirm>
+              {record.account_status === 'active' ? '禁用' : '启用'}
+            </Button>
           </PermissionGuard>
-        </Space>
+        </Stack>
       ),
     },
   ];

--- a/frontend/src/pages/accounts/ElderAccountPage.tsx
+++ b/frontend/src/pages/accounts/ElderAccountPage.tsx
@@ -1,12 +1,14 @@
 import React, { useCallback } from 'react';
-import { Button, Tag, Space, Popconfirm, message } from 'antd';
-import type { ColumnsType } from 'antd/es/table';
-import AppTable from '../../components/AppTable';
+import { Button, Chip, Stack } from '@mui/material';
+import RestartAltRoundedIcon from '@mui/icons-material/RestartAltRounded';
+import PowerSettingsNewRoundedIcon from '@mui/icons-material/PowerSettingsNewRounded';
+import AppTable, { type AppTableColumn } from '../../components/AppTable';
 import PermissionGuard from '../../components/PermissionGuard';
 import { useTable } from '../../hooks/useTable';
 import { getElders, resetElderPassword, updateElderAccountStatus } from '../../api/elders';
 import { formatGender } from '../../utils/formatter';
 import type { Elder, ElderListQuery } from '../../types/elder';
+import { message } from '../../utils/message';
 
 const ElderAccountPage: React.FC = () => {
   const fetchFn = useCallback(
@@ -18,6 +20,10 @@ const ElderAccountPage: React.FC = () => {
     useTable<Elder, ElderListQuery>(fetchFn);
 
   const handleResetPassword = async (elderId: number) => {
+    if (!window.confirm('确定重置密码？')) {
+      return;
+    }
+
     try {
       await resetElderPassword(elderId);
       message.success('密码重置成功');
@@ -28,6 +34,10 @@ const ElderAccountPage: React.FC = () => {
 
   const handleToggleStatus = async (elderId: number, currentStatus: string) => {
     const newStatus = currentStatus === 'active' ? 'disabled' : 'active';
+    if (!window.confirm(`确定${newStatus === 'active' ? '启用' : '禁用'}该账户？`)) {
+      return;
+    }
+
     try {
       await updateElderAccountStatus(elderId, newStatus);
       message.success(newStatus === 'active' ? '已启用' : '已禁用');
@@ -37,7 +47,7 @@ const ElderAccountPage: React.FC = () => {
     }
   };
 
-  const columns: ColumnsType<Elder> = [
+  const columns: AppTableColumn<Elder>[] = [
     { title: '姓名', dataIndex: 'name', width: 100 },
     { title: '性别', dataIndex: 'gender', width: 80, render: formatGender },
     { title: '联系电话', dataIndex: 'phone', width: 130 },
@@ -47,9 +57,12 @@ const ElderAccountPage: React.FC = () => {
       dataIndex: 'account_status',
       width: 100,
       render: (status: string) => (
-        <Tag color={status === 'active' ? 'green' : 'red'}>
-          {status === 'active' ? '正常' : '已禁用'}
-        </Tag>
+        <Chip
+          size="small"
+          color={status === 'active' ? 'success' : 'error'}
+          variant="outlined"
+          label={status === 'active' ? '正常' : '已禁用'}
+        />
       ),
     },
     {
@@ -58,28 +71,27 @@ const ElderAccountPage: React.FC = () => {
       width: 220,
       fixed: 'right',
       render: (_, record) => (
-        <Space>
+        <Stack direction="row" spacing={0.5}>
           <PermissionGuard permission="elder:update">
-            <Popconfirm
-              title="确定重置密码？"
-              onConfirm={() => handleResetPassword(record.id)}
+            <Button
+              size="small"
+              variant="text"
+              startIcon={<RestartAltRoundedIcon fontSize="small" />}
+              onClick={() => handleResetPassword(record.id)}
             >
-              <Button type="link" size="small">重置密码</Button>
-            </Popconfirm>
-            <Popconfirm
-              title={`确定${record.account_status === 'active' ? '禁用' : '启用'}该账户？`}
-              onConfirm={() => handleToggleStatus(record.id, record.account_status)}
+              重置密码
+            </Button>
+            <Button
+              size="small"
+              variant="text"
+              color={record.account_status === 'active' ? 'error' : 'primary'}
+              startIcon={<PowerSettingsNewRoundedIcon fontSize="small" />}
+              onClick={() => handleToggleStatus(record.id, record.account_status)}
             >
-              <Button
-                type="link"
-                size="small"
-                danger={record.account_status === 'active'}
-              >
-                {record.account_status === 'active' ? '禁用' : '启用'}
-              </Button>
-            </Popconfirm>
+              {record.account_status === 'active' ? '禁用' : '启用'}
+            </Button>
           </PermissionGuard>
-        </Space>
+        </Stack>
       ),
     },
   ];

--- a/frontend/src/pages/accounts/PersonalAccountPage.tsx
+++ b/frontend/src/pages/accounts/PersonalAccountPage.tsx
@@ -1,30 +1,85 @@
 import React, { useState } from 'react';
-import { Card, Descriptions, Form, Input, Button, Divider, message } from 'antd';
+import {
+  Box,
+  Button,
+  Card,
+  CardContent,
+  Divider,
+  Stack,
+  TextField,
+  Typography,
+} from '@mui/material';
 import { useAuthStore } from '../../store/auth';
 import { changePassword } from '../../api/auth';
+import { message } from '../../utils/message';
+
+interface PasswordFormValues {
+  old_password: string;
+  new_password: string;
+  confirm_password: string;
+}
+
+type PasswordFormErrors = Partial<Record<keyof PasswordFormValues, string>>;
+
+const initialValues: PasswordFormValues = {
+  old_password: '',
+  new_password: '',
+  confirm_password: '',
+};
+
+function validatePasswordForm(values: PasswordFormValues): PasswordFormErrors {
+  const errors: PasswordFormErrors = {};
+
+  if (!values.old_password) {
+    errors.old_password = '请输入当前密码';
+  }
+  if (!values.new_password) {
+    errors.new_password = '请输入新密码';
+  } else if (values.new_password.length < 6) {
+    errors.new_password = '密码至少6个字符';
+  }
+  if (!values.confirm_password) {
+    errors.confirm_password = '请再次输入新密码';
+  } else if (values.confirm_password !== values.new_password) {
+    errors.confirm_password = '两次输入的密码不一致';
+  }
+
+  return errors;
+}
 
 const PersonalAccountPage: React.FC = () => {
   const user = useAuthStore((state) => state.user);
   const [loading, setLoading] = useState(false);
-  const [form] = Form.useForm();
+  const [values, setValues] = useState<PasswordFormValues>(initialValues);
+  const [errors, setErrors] = useState<PasswordFormErrors>({});
 
-  const handleChangePassword = async (values: {
-    old_password: string;
-    new_password: string;
-    confirm_password: string;
-  }) => {
-    if (values.new_password !== values.confirm_password) {
-      message.error('两次输入的密码不一致');
+  const updateField = <K extends keyof PasswordFormValues>(key: K, value: PasswordFormValues[K]) => {
+    setValues((current) => ({
+      ...current,
+      [key]: value,
+    }));
+    setErrors((current) => ({
+      ...current,
+      [key]: '',
+    }));
+  };
+
+  const handleChangePassword = async (nextValues: PasswordFormValues) => {
+    const nextErrors = validatePasswordForm(nextValues);
+    setErrors(nextErrors);
+    if (Object.keys(nextErrors).length > 0) {
       return;
     }
+
     setLoading(true);
     try {
       await changePassword({
-        old_password: values.old_password,
-        new_password: values.new_password,
+        old_password: nextValues.old_password,
+        new_password: nextValues.new_password,
       });
       message.success('密码修改成功');
-      form.resetFields();
+      setValues(initialValues);
+      setErrors({});
     } catch (err) {
       message.error(err instanceof Error ? err.message : '修改失败');
     } finally {
@@ -33,71 +88,98 @@ const PersonalAccountPage: React.FC = () => {
   };
 
   return (
-    <div>
-      <Card title="个人信息" style={{ marginBottom: 16 }}>
-        <Descriptions column={{ xs: 1, sm: 2 }}>
-          <Descriptions.Item label="用户名">{user?.username || '-'}</Descriptions.Item>
-          <Descriptions.Item label="姓名">{user?.real_name || '-'}</Descriptions.Item>
-          <Descriptions.Item label="手机号">{user?.phone || '-'}</Descriptions.Item>
-          <Descriptions.Item label="邮箱">{user?.email || '-'}</Descriptions.Item>
-          <Descriptions.Item label="角色">{user?.roles?.join(', ') || '-'}</Descriptions.Item>
-        </Descriptions>
+    <Stack spacing={3}>
+      <Card>
+        <CardContent>
+          <Typography variant="h6" sx={{ fontWeight: 700, mb: 2 }}>
+            个人信息
+          </Typography>
+          <Box
+            sx={{
+              display: 'grid',
+              gridTemplateColumns: { xs: '1fr', sm: 'repeat(2, minmax(0, 1fr))' },
+              gap: 2,
+            }}
+          >
+            {[
+              ['用户名', user?.username || '-'],
+              ['姓名', user?.real_name || '-'],
+              ['手机号', user?.phone || '-'],
+              ['邮箱', user?.email || '-'],
+              ['角色', user?.roles?.join(', ') || '-'],
+            ].map(([label, value]) => (
+              <Box key={label as string} sx={{ p: 2, borderRadius: 2, bgcolor: 'background.default' }}>
+                <Typography variant="body2" color="text.secondary">
+                  {label}
+                </Typography>
+                <Typography variant="subtitle1" sx={{ mt: 0.5, fontWeight: 600 }}>
+                  {value}
+                </Typography>
+              </Box>
+            ))}
+          </Box>
+        </CardContent>
       </Card>
 
-      <Card title="修改密码">
-        <Form
-          form={form}
-          layout="vertical"
-          onFinish={handleChangePassword}
-          style={{ maxWidth: 400 }}
-        >
-          <Form.Item
-            name="old_password"
-            label="当前密码"
-            rules={[{ required: true, message: '请输入当前密码' }]}
+      <Card>
+        <CardContent>
+          <Typography variant="h6" sx={{ fontWeight: 700, mb: 1 }}>
+            修改密码
+          </Typography>
+          <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+            密码至少 6 个字符，确认新密码需保持一致。
+          </Typography>
+
+          <Box
+            component="form"
+            onSubmit={(event) => {
+              event.preventDefault();
+              void handleChangePassword(values);
+            }}
+            noValidate
+            sx={{ maxWidth: 440 }}
           >
-            <Input.Password placeholder="请输入当前密码" />
-          </Form.Item>
+            <Stack spacing={2.25}>
+              <TextField
+                label="当前密码"
+                type="password"
+                value={values.old_password}
+                onChange={(event) => updateField('old_password', event.target.value)}
+                error={Boolean(errors.old_password)}
+                helperText={errors.old_password || ' '}
+                fullWidth
+              />
 
-          <Divider />
+              <Divider />
 
-          <Form.Item
-            name="new_password"
-            label="新密码"
-            rules={[
-              { required: true, message: '请输入新密码' },
-              { min: 6, message: '密码至少6个字符' },
-            ]}
-          >
-            <Input.Password placeholder="请输入新密码" />
-          </Form.Item>
+              <TextField
+                label="新密码"
+                type="password"
+                value={values.new_password}
+                onChange={(event) => updateField('new_password', event.target.value)}
+                error={Boolean(errors.new_password)}
+                helperText={errors.new_password || ' '}
+                fullWidth
+              />
 
-          <Form.Item
-            name="confirm_password"
-            label="确认新密码"
-            rules={[
-              { required: true, message: '请再次输入新密码' },
-              ({ getFieldValue }) => ({
-                validator(_, value) {
-                  if (!value || getFieldValue('new_password') === value) {
-                    return Promise.resolve();
-                  }
-                  return Promise.reject(new Error('两次输入的密码不一致'));
-                },
-              }),
-            ]}
-          >
-            <Input.Password placeholder="请再次输入新密码" />
-          </Form.Item>
+              <TextField
+                label="确认新密码"
+                type="password"
+                value={values.confirm_password}
+                onChange={(event) => updateField('confirm_password', event.target.value)}
+                error={Boolean(errors.confirm_password)}
+                helperText={errors.confirm_password || ' '}
+                fullWidth
+              />
 
-          <Form.Item>
-            <Button type="primary" htmlType="submit" loading={loading}>
-              修改密码
-            </Button>
-          </Form.Item>
-        </Form>
+              <Button type="submit" variant="contained" disabled={loading}>
+                {loading ? '修改中...' : '修改密码'}
+              </Button>
+            </Stack>
+          </Box>
+        </CardContent>
       </Card>
-    </div>
+    </Stack>
   );
 };
 

--- a/frontend/src/pages/alerts/AlertDetailPage.tsx
+++ b/frontend/src/pages/alerts/AlertDetailPage.tsx
@@ -1,13 +1,52 @@
 import React, { useEffect, useState, useCallback } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
-import { Card, Descriptions, Tag, Button, Space, Steps, Spin, Popconfirm, message } from 'antd';
-import { ArrowLeftOutlined } from '@ant-design/icons';
+import {
+  Box,
+  Button,
+  Card,
+  CardContent,
+  Chip,
+  CircularProgress,
+  Stack,
+  Step,
+  StepLabel,
+  Stepper,
+  Typography,
+} from '@mui/material';
+import ArrowBackRoundedIcon from '@mui/icons-material/ArrowBackRounded';
+import ManageSearchRoundedIcon from '@mui/icons-material/ManageSearchRounded';
+import TaskAltRoundedIcon from '@mui/icons-material/TaskAltRounded';
+import BlockRoundedIcon from '@mui/icons-material/BlockRounded';
 import { getAlertDetail, updateAlertStatus } from '../../api/alerts';
 import { formatDateTime, formatRiskLevel, formatAlertStatus } from '../../utils/formatter';
 import { RISK_LEVEL_COLORS, ALERT_STATUS_COLORS } from '../../utils/constants';
+import { message } from '../../utils/message';
 import type { Alert } from '../../types/alert';
 
-const statusSteps = ['pending', 'processing', 'resolved'];
+const statusSteps = ['pending', 'processing', 'resolved'] as const;
+
+function DetailItem({
+  label,
+  value,
+  fullWidth = false,
+}: {
+  label: string;
+  value?: React.ReactNode;
+  fullWidth?: boolean;
+}) {
+  return (
+    <Box sx={{ gridColumn: fullWidth ? '1 / -1' : 'auto' }}>
+      <Stack spacing={0.5}>
+        <Typography variant="caption" color="text.secondary">
+          {label}
+        </Typography>
+        <Typography variant="body1" sx={{ wordBreak: 'break-word' }}>
+          {value ?? '-'}
+        </Typography>
+      </Stack>
+    </Box>
+  );
+}
 
 const AlertDetailPage: React.FC = () => {
   const { id } = useParams<{ id: string }>();
@@ -33,9 +72,13 @@ const AlertDetailPage: React.FC = () => {
     fetchAlert();
   }, [fetchAlert]);
 
-  const handleStatusUpdate = async (status: string) => {
+  const handleStatusUpdate = async (status: Alert['status']) => {
+    if (!window.confirm(`确认将该预警标记为${formatAlertStatus(status)}？`)) {
+      return;
+    }
+
     try {
-      await updateAlertStatus(alertId, { status: status as Alert['status'] });
+      await updateAlertStatus(alertId, { status });
       message.success('状态更新成功');
       fetchAlert();
     } catch (err) {
@@ -43,89 +86,193 @@ const AlertDetailPage: React.FC = () => {
     }
   };
 
-  const currentStep = alert?.status === 'ignored'
-    ? -1
-    : statusSteps.indexOf(alert?.status || 'pending');
+  const currentStep =
+    alert?.status === 'ignored' ? 0 : statusSteps.indexOf(alert?.status || 'pending');
 
   if (loading) {
-    return <div style={{ textAlign: 'center', padding: 100 }}><Spin size="large" /></div>;
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', py: 12 }}>
+        <CircularProgress size={40} />
+      </Box>
+    );
   }
 
   return (
-    <div>
+    <Box sx={{ display: 'grid', gap: 2 }}>
       <Button
-        icon={<ArrowLeftOutlined />}
+        startIcon={<ArrowBackRoundedIcon />}
         onClick={() => navigate('/alerts')}
-        style={{ marginBottom: 16 }}
+        sx={{ alignSelf: 'flex-start' }}
       >
         返回列表
       </Button>
 
-      <Card title="预警详情" style={{ marginBottom: 16 }}>
-        <Descriptions column={{ xs: 1, sm: 2 }} bordered>
-          <Descriptions.Item label="预警标题">{alert?.title}</Descriptions.Item>
-          <Descriptions.Item label="预警类型">{alert?.type}</Descriptions.Item>
-          <Descriptions.Item label="风险等级">
-            <Tag color={RISK_LEVEL_COLORS[alert?.risk_level || '']}>
-              {formatRiskLevel(alert?.risk_level)}
-            </Tag>
-          </Descriptions.Item>
-          <Descriptions.Item label="状态">
-            <Tag color={ALERT_STATUS_COLORS[alert?.status || '']}>
-              {formatAlertStatus(alert?.status)}
-            </Tag>
-          </Descriptions.Item>
-          <Descriptions.Item label="来源">{alert?.source || '-'}</Descriptions.Item>
-          <Descriptions.Item label="老人ID">{alert?.elder_id}</Descriptions.Item>
-          <Descriptions.Item label="触发时间" span={2}>
-            {formatDateTime(alert?.triggered_at)}
-          </Descriptions.Item>
-          <Descriptions.Item label="描述" span={2}>
-            {alert?.description}
-          </Descriptions.Item>
-          {alert?.remark && (
-            <Descriptions.Item label="备注" span={2}>
-              {alert.remark}
-            </Descriptions.Item>
-          )}
-        </Descriptions>
-      </Card>
+      <Card>
+        <CardContent>
+          <Stack direction={{ xs: 'column', sm: 'row' }} justifyContent="space-between" spacing={2}>
+            <Box>
+              <Typography variant="h5" sx={{ mb: 0.5 }}>
+                预警详情
+              </Typography>
+              <Typography variant="body2" color="text.secondary">
+                查看预警基础信息、处理进度和后续操作
+              </Typography>
+            </Box>
+            <Stack direction="row" spacing={1} flexWrap="wrap">
+              <Chip
+                size="small"
+                label={formatRiskLevel(alert?.risk_level)}
+                sx={{
+                  color: RISK_LEVEL_COLORS[alert?.risk_level || ''] || 'text.primary',
+                  borderColor: RISK_LEVEL_COLORS[alert?.risk_level || ''] || 'divider',
+                  bgcolor: 'transparent',
+                }}
+                variant="outlined"
+              />
+              <Chip
+                size="small"
+                label={formatAlertStatus(alert?.status)}
+                sx={{
+                  color: ALERT_STATUS_COLORS[alert?.status || ''] || 'text.primary',
+                  borderColor: ALERT_STATUS_COLORS[alert?.status || ''] || 'divider',
+                  bgcolor: 'transparent',
+                }}
+                variant="outlined"
+              />
+            </Stack>
+          </Stack>
 
-      <Card title="处理进度" style={{ marginBottom: 16 }}>
-        <Steps
-          current={currentStep}
-          status={alert?.status === 'ignored' ? 'error' : undefined}
-          items={[
-            { title: '待处理', description: formatDateTime(alert?.triggered_at) },
-            { title: '处理中' },
-            { title: '已解决', description: alert?.resolved_at ? formatDateTime(alert.resolved_at) : undefined },
-          ]}
-        />
+          <Box
+            sx={{
+              mt: 2,
+              display: 'grid',
+              gap: 2,
+              gridTemplateColumns: { xs: '1fr', sm: 'repeat(2, minmax(0, 1fr))' },
+            }}
+          >
+            <DetailItem label="预警标题" value={alert?.title} />
+            <DetailItem label="预警类型" value={alert?.type} />
+            <DetailItem
+              label="风险等级"
+              value={
+                <Chip
+                  size="small"
+                  label={formatRiskLevel(alert?.risk_level)}
+                  sx={{
+                    color: RISK_LEVEL_COLORS[alert?.risk_level || ''] || 'text.primary',
+                    borderColor: RISK_LEVEL_COLORS[alert?.risk_level || ''] || 'divider',
+                    bgcolor: 'transparent',
+                  }}
+                  variant="outlined"
+                />
+              }
+            />
+            <DetailItem
+              label="状态"
+              value={
+                <Chip
+                  size="small"
+                  label={formatAlertStatus(alert?.status)}
+                  sx={{
+                    color: ALERT_STATUS_COLORS[alert?.status || ''] || 'text.primary',
+                    borderColor: ALERT_STATUS_COLORS[alert?.status || ''] || 'divider',
+                    bgcolor: 'transparent',
+                  }}
+                  variant="outlined"
+                />
+              }
+            />
+            <DetailItem label="来源" value={alert?.source || '-'} />
+            <DetailItem label="老人ID" value={alert?.elder_id} />
+            <DetailItem label="触发时间" value={formatDateTime(alert?.triggered_at)} fullWidth />
+            <DetailItem label="描述" value={alert?.description} fullWidth />
+            {alert?.remark && <DetailItem label="备注" value={alert.remark} fullWidth />}
+          </Box>
+        </CardContent>
       </Card>
 
       <Card>
-        <Space>
-          {alert?.status === 'pending' && (
-            <Popconfirm title="确认开始处理？" onConfirm={() => handleStatusUpdate('processing')}>
-              <Button type="primary">开始处理</Button>
-            </Popconfirm>
+        <CardContent>
+          <Typography variant="h6" sx={{ mb: 2 }}>
+            处理进度
+          </Typography>
+          {alert?.status === 'ignored' && (
+            <Chip
+              color="default"
+              variant="outlined"
+              label="该预警已忽略，未进入标准处理流程"
+              sx={{ mb: 2 }}
+            />
           )}
-          {alert?.status === 'processing' && (
-            <Popconfirm title="确认已解决？" onConfirm={() => handleStatusUpdate('resolved')}>
-              <Button type="primary">标记解决</Button>
-            </Popconfirm>
-          )}
-          {(alert?.status === 'pending' || alert?.status === 'processing') && (
-            <Popconfirm title="确认忽略此预警？" onConfirm={() => handleStatusUpdate('ignored')}>
-              <Button danger>忽略</Button>
-            </Popconfirm>
-          )}
-          <Button onClick={() => navigate(`/elders/${alert?.elder_id}`)}>
-            查看老人信息
-          </Button>
-        </Space>
+          <Stepper activeStep={Math.max(currentStep, 0)} alternativeLabel>
+            <Step>
+              <StepLabel>
+                <Stack spacing={0.5} alignItems="center">
+                  <Typography variant="body2">待处理</Typography>
+                  <Typography variant="caption" color="text.secondary">
+                    {formatDateTime(alert?.triggered_at)}
+                  </Typography>
+                </Stack>
+              </StepLabel>
+            </Step>
+            <Step>
+              <StepLabel>
+                <Typography variant="body2">处理中</Typography>
+              </StepLabel>
+            </Step>
+            <Step>
+              <StepLabel>
+                <Stack spacing={0.5} alignItems="center">
+                  <Typography variant="body2">已解决</Typography>
+                  <Typography variant="caption" color="text.secondary">
+                    {alert?.resolved_at ? formatDateTime(alert.resolved_at) : '-'}
+                  </Typography>
+                </Stack>
+              </StepLabel>
+            </Step>
+          </Stepper>
+        </CardContent>
       </Card>
-    </div>
+
+      <Card>
+        <CardContent>
+          <Stack direction="row" spacing={1} flexWrap="wrap">
+            {alert?.status === 'pending' && (
+              <Button
+                variant="contained"
+                startIcon={<ManageSearchRoundedIcon />}
+                onClick={() => handleStatusUpdate('processing')}
+              >
+                开始处理
+              </Button>
+            )}
+            {alert?.status === 'processing' && (
+              <Button
+                variant="contained"
+                color="success"
+                startIcon={<TaskAltRoundedIcon />}
+                onClick={() => handleStatusUpdate('resolved')}
+              >
+                标记解决
+              </Button>
+            )}
+            {(alert?.status === 'pending' || alert?.status === 'processing') && (
+              <Button
+                variant="outlined"
+                color="inherit"
+                startIcon={<BlockRoundedIcon />}
+                onClick={() => handleStatusUpdate('ignored')}
+              >
+                忽略
+              </Button>
+            )}
+            <Button variant="outlined" onClick={() => navigate(`/elders/${alert?.elder_id}`)}>
+              查看老人信息
+            </Button>
+          </Stack>
+        </CardContent>
+      </Card>
+    </Box>
   );
 };
 

--- a/frontend/src/pages/alerts/AlertDetailPage.tsx
+++ b/frontend/src/pages/alerts/AlertDetailPage.tsx
@@ -1,13 +1,45 @@
 import React, { useEffect, useState, useCallback } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
-import { Card, Descriptions, Tag, Button, Space, Steps, Spin, Popconfirm, message } from 'antd';
-import { ArrowLeftOutlined } from '@ant-design/icons';
+import {
+  Box,
+  Button,
+  Card,
+  CardContent,
+  Chip,
+  CircularProgress,
+  Grid,
+  Stack,
+  Step,
+  StepLabel,
+  Stepper,
+  Typography,
+} from '@mui/material';
+import ArrowBackRoundedIcon from '@mui/icons-material/ArrowBackRounded';
+import ManageSearchRoundedIcon from '@mui/icons-material/ManageSearchRounded';
+import TaskAltRoundedIcon from '@mui/icons-material/TaskAltRounded';
+import BlockRoundedIcon from '@mui/icons-material/BlockRounded';
 import { getAlertDetail, updateAlertStatus } from '../../api/alerts';
 import { formatDateTime, formatRiskLevel, formatAlertStatus } from '../../utils/formatter';
 import { RISK_LEVEL_COLORS, ALERT_STATUS_COLORS } from '../../utils/constants';
+import { message } from '../../utils/message';
 import type { Alert } from '../../types/alert';
 
-const statusSteps = ['pending', 'processing', 'resolved'];
+const statusSteps = ['pending', 'processing', 'resolved'] as const;
+
+function DetailItem({ label, value, fullWidth = false }: { label: string; value?: React.ReactNode; fullWidth?: boolean }) {
+  return (
+    <Grid item xs={12} sm={fullWidth ? 12 : 6}>
+      <Stack spacing={0.5}>
+        <Typography variant="caption" color="text.secondary">
+          {label}
+        </Typography>
+        <Typography variant="body1" sx={{ wordBreak: 'break-word' }}>
+          {value ?? '-'}
+        </Typography>
+      </Stack>
+    </Grid>
+  );
+}
 
 const AlertDetailPage: React.FC = () => {
   const { id } = useParams<{ id: string }>();
@@ -33,9 +65,13 @@ const AlertDetailPage: React.FC = () => {
     fetchAlert();
   }, [fetchAlert]);
 
-  const handleStatusUpdate = async (status: string) => {
+  const handleStatusUpdate = async (status: Alert['status']) => {
+    if (!window.confirm(`确认将该预警标记为${formatAlertStatus(status)}？`)) {
+      return;
+    }
+
     try {
-      await updateAlertStatus(alertId, { status: status as Alert['status'] });
+      await updateAlertStatus(alertId, { status });
       message.success('状态更新成功');
       fetchAlert();
     } catch (err) {
@@ -44,88 +80,186 @@ const AlertDetailPage: React.FC = () => {
   };
 
   const currentStep = alert?.status === 'ignored'
-    ? -1
+    ? 0
     : statusSteps.indexOf(alert?.status || 'pending');
 
   if (loading) {
-    return <div style={{ textAlign: 'center', padding: 100 }}><Spin size="large" /></div>;
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', py: 12 }}>
+        <CircularProgress size={40} />
+      </Box>
+    );
   }
 
   return (
-    <div>
+    <Box sx={{ display: 'grid', gap: 2 }}>
       <Button
-        icon={<ArrowLeftOutlined />}
+        startIcon={<ArrowBackRoundedIcon />}
         onClick={() => navigate('/alerts')}
-        style={{ marginBottom: 16 }}
+        sx={{ alignSelf: 'flex-start' }}
       >
         返回列表
       </Button>
 
-      <Card title="预警详情" style={{ marginBottom: 16 }}>
-        <Descriptions column={{ xs: 1, sm: 2 }} bordered>
-          <Descriptions.Item label="预警标题">{alert?.title}</Descriptions.Item>
-          <Descriptions.Item label="预警类型">{alert?.type}</Descriptions.Item>
-          <Descriptions.Item label="风险等级">
-            <Tag color={RISK_LEVEL_COLORS[alert?.risk_level || '']}>
-              {formatRiskLevel(alert?.risk_level)}
-            </Tag>
-          </Descriptions.Item>
-          <Descriptions.Item label="状态">
-            <Tag color={ALERT_STATUS_COLORS[alert?.status || '']}>
-              {formatAlertStatus(alert?.status)}
-            </Tag>
-          </Descriptions.Item>
-          <Descriptions.Item label="来源">{alert?.source || '-'}</Descriptions.Item>
-          <Descriptions.Item label="老人ID">{alert?.elder_id}</Descriptions.Item>
-          <Descriptions.Item label="触发时间" span={2}>
-            {formatDateTime(alert?.triggered_at)}
-          </Descriptions.Item>
-          <Descriptions.Item label="描述" span={2}>
-            {alert?.description}
-          </Descriptions.Item>
-          {alert?.remark && (
-            <Descriptions.Item label="备注" span={2}>
-              {alert.remark}
-            </Descriptions.Item>
-          )}
-        </Descriptions>
-      </Card>
+      <Card>
+        <CardContent>
+          <Stack direction={{ xs: 'column', sm: 'row' }} justifyContent="space-between" spacing={2}>
+            <Box>
+              <Typography variant="h5" sx={{ mb: 0.5 }}>
+                预警详情
+              </Typography>
+              <Typography variant="body2" color="text.secondary">
+                查看预警基础信息、处理进度和后续操作
+              </Typography>
+            </Box>
+            <Stack direction="row" spacing={1} flexWrap="wrap">
+              <Chip
+                size="small"
+                label={formatRiskLevel(alert?.risk_level)}
+                sx={{
+                  color: RISK_LEVEL_COLORS[alert?.risk_level || ''] || 'text.primary',
+                  borderColor: RISK_LEVEL_COLORS[alert?.risk_level || ''] || 'divider',
+                  bgcolor: 'transparent',
+                }}
+                variant="outlined"
+              />
+              <Chip
+                size="small"
+                label={formatAlertStatus(alert?.status)}
+                sx={{
+                  color: ALERT_STATUS_COLORS[alert?.status || ''] || 'text.primary',
+                  borderColor: ALERT_STATUS_COLORS[alert?.status || ''] || 'divider',
+                  bgcolor: 'transparent',
+                }}
+                variant="outlined"
+              />
+            </Stack>
+          </Stack>
 
-      <Card title="处理进度" style={{ marginBottom: 16 }}>
-        <Steps
-          current={currentStep}
-          status={alert?.status === 'ignored' ? 'error' : undefined}
-          items={[
-            { title: '待处理', description: formatDateTime(alert?.triggered_at) },
-            { title: '处理中' },
-            { title: '已解决', description: alert?.resolved_at ? formatDateTime(alert.resolved_at) : undefined },
-          ]}
-        />
+          <Grid container spacing={2} sx={{ mt: 2 }}>
+            <DetailItem label="预警标题" value={alert?.title} />
+            <DetailItem label="预警类型" value={alert?.type} />
+            <DetailItem
+              label="风险等级"
+              value={
+                <Chip
+                  size="small"
+                  label={formatRiskLevel(alert?.risk_level)}
+                  sx={{
+                    color: RISK_LEVEL_COLORS[alert?.risk_level || ''] || 'text.primary',
+                    borderColor: RISK_LEVEL_COLORS[alert?.risk_level || ''] || 'divider',
+                    bgcolor: 'transparent',
+                  }}
+                  variant="outlined"
+                />
+              }
+            />
+            <DetailItem
+              label="状态"
+              value={
+                <Chip
+                  size="small"
+                  label={formatAlertStatus(alert?.status)}
+                  sx={{
+                    color: ALERT_STATUS_COLORS[alert?.status || ''] || 'text.primary',
+                    borderColor: ALERT_STATUS_COLORS[alert?.status || ''] || 'divider',
+                    bgcolor: 'transparent',
+                  }}
+                  variant="outlined"
+                />
+              }
+            />
+            <DetailItem label="来源" value={alert?.source || '-'} />
+            <DetailItem label="老人ID" value={alert?.elder_id} />
+            <DetailItem label="触发时间" value={formatDateTime(alert?.triggered_at)} fullWidth />
+            <DetailItem label="描述" value={alert?.description} fullWidth />
+            {alert?.remark && <DetailItem label="备注" value={alert.remark} fullWidth />}
+          </Grid>
+        </CardContent>
       </Card>
 
       <Card>
-        <Space>
-          {alert?.status === 'pending' && (
-            <Popconfirm title="确认开始处理？" onConfirm={() => handleStatusUpdate('processing')}>
-              <Button type="primary">开始处理</Button>
-            </Popconfirm>
+        <CardContent>
+          <Typography variant="h6" sx={{ mb: 2 }}>
+            处理进度
+          </Typography>
+          {alert?.status === 'ignored' && (
+            <Chip
+              color="default"
+              variant="outlined"
+              label="该预警已忽略，未进入标准处理流程"
+              sx={{ mb: 2 }}
+            />
           )}
-          {alert?.status === 'processing' && (
-            <Popconfirm title="确认已解决？" onConfirm={() => handleStatusUpdate('resolved')}>
-              <Button type="primary">标记解决</Button>
-            </Popconfirm>
-          )}
-          {(alert?.status === 'pending' || alert?.status === 'processing') && (
-            <Popconfirm title="确认忽略此预警？" onConfirm={() => handleStatusUpdate('ignored')}>
-              <Button danger>忽略</Button>
-            </Popconfirm>
-          )}
-          <Button onClick={() => navigate(`/elders/${alert?.elder_id}`)}>
-            查看老人信息
-          </Button>
-        </Space>
+          <Stepper activeStep={Math.max(currentStep, 0)} alternativeLabel>
+            <Step>
+              <StepLabel>
+                <Stack spacing={0.5} alignItems="center">
+                  <Typography variant="body2">待处理</Typography>
+                  <Typography variant="caption" color="text.secondary">
+                    {formatDateTime(alert?.triggered_at)}
+                  </Typography>
+                </Stack>
+              </StepLabel>
+            </Step>
+            <Step>
+              <StepLabel>
+                <Typography variant="body2">处理中</Typography>
+              </StepLabel>
+            </Step>
+            <Step>
+              <StepLabel>
+                <Stack spacing={0.5} alignItems="center">
+                  <Typography variant="body2">已解决</Typography>
+                  <Typography variant="caption" color="text.secondary">
+                    {alert?.resolved_at ? formatDateTime(alert.resolved_at) : '-'}
+                  </Typography>
+                </Stack>
+              </StepLabel>
+            </Step>
+          </Stepper>
+        </CardContent>
       </Card>
-    </div>
+
+      <Card>
+        <CardContent>
+          <Stack direction="row" spacing={1} flexWrap="wrap">
+            {alert?.status === 'pending' && (
+              <Button
+                variant="contained"
+                startIcon={<ManageSearchRoundedIcon />}
+                onClick={() => handleStatusUpdate('processing')}
+              >
+                开始处理
+              </Button>
+            )}
+            {alert?.status === 'processing' && (
+              <Button
+                variant="contained"
+                color="success"
+                startIcon={<TaskAltRoundedIcon />}
+                onClick={() => handleStatusUpdate('resolved')}
+              >
+                标记解决
+              </Button>
+            )}
+            {(alert?.status === 'pending' || alert?.status === 'processing') && (
+              <Button
+                variant="outlined"
+                color="inherit"
+                startIcon={<BlockRoundedIcon />}
+                onClick={() => handleStatusUpdate('ignored')}
+              >
+                忽略
+              </Button>
+            )}
+            <Button variant="outlined" onClick={() => navigate(`/elders/${alert?.elder_id}`)}>
+              查看老人信息
+            </Button>
+          </Stack>
+        </CardContent>
+      </Card>
+    </Box>
   );
 };
 

--- a/frontend/src/pages/alerts/AlertListPage.tsx
+++ b/frontend/src/pages/alerts/AlertListPage.tsx
@@ -1,8 +1,21 @@
-import React, { useState, useCallback } from 'react';
-import { Button, Tag, Space, Select, DatePicker, Popconfirm, message } from 'antd';
-import { PlusOutlined, EyeOutlined } from '@ant-design/icons';
-import { useNavigate } from 'react-router-dom';
-import type { ColumnsType } from 'antd/es/table';
+import React, { useCallback, useState } from 'react';
+import {
+  Box,
+  Button,
+  Chip,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+  Stack,
+  TextField,
+} from '@mui/material';
+import AddRoundedIcon from '@mui/icons-material/AddRounded';
+import VisibilityRoundedIcon from '@mui/icons-material/VisibilityRounded';
+import ManageSearchRoundedIcon from '@mui/icons-material/ManageSearchRounded';
+import TaskAltRoundedIcon from '@mui/icons-material/TaskAltRounded';
+import BlockRoundedIcon from '@mui/icons-material/BlockRounded';
+import type { AppTableColumn } from '../../components/AppTable';
 import AppTable from '../../components/AppTable';
 import AppForm, { type FormFieldConfig } from '../../components/AppForm';
 import PermissionGuard from '../../components/PermissionGuard';
@@ -20,9 +33,9 @@ import {
   RISK_LEVEL_COLORS,
   ALERT_STATUS_COLORS,
 } from '../../utils/constants';
+import { message } from '../../utils/message';
+import { useNavigate } from 'react-router-dom';
 import type { Alert, AlertListQuery } from '../../types/alert';
-
-const { RangePicker } = DatePicker;
 
 const createFields: FormFieldConfig[] = [
   { name: 'elder_id', label: '老人ID', type: 'number', required: true },
@@ -51,9 +64,13 @@ const AlertListPage: React.FC = () => {
   const { data, loading, pagination, handleTableChange, refresh, handleSearch, query, setQuery } =
     useTable<Alert, AlertListQuery>(fetchFn);
 
-  const handleStatusUpdate = async (id: number, status: string) => {
+  const handleStatusUpdate = async (id: number, status: Alert['status']) => {
+    if (!window.confirm(`确认将该预警标记为${formatAlertStatus(status)}？`)) {
+      return;
+    }
+
     try {
-      await updateAlertStatus(id, { status: status as Alert['status'] });
+      await updateAlertStatus(id, { status });
       message.success('状态更新成功');
       refresh();
     } catch (err) {
@@ -66,6 +83,11 @@ const AlertListPage: React.FC = () => {
       message.warning('请选择要处理的预警');
       return;
     }
+
+    if (!window.confirm(`确认将选中的预警批量标记为${formatAlertStatus(status)}？`)) {
+      return;
+    }
+
     try {
       await batchUpdateAlertStatus({
         ids: selectedRowKeys as number[],
@@ -80,24 +102,48 @@ const AlertListPage: React.FC = () => {
     }
   };
 
-  const columns: ColumnsType<Alert> = [
-    { title: '预警标题', dataIndex: 'title', width: 200 },
+  const columns: AppTableColumn<Alert>[] = [
+    { title: '预警标题', dataIndex: 'title', width: 220 },
     { title: '类型', dataIndex: 'type', width: 150 },
     {
       title: '风险等级',
       dataIndex: 'risk_level',
-      width: 100,
-      render: (level: string) => (
-        <Tag color={RISK_LEVEL_COLORS[level]}>{formatRiskLevel(level)}</Tag>
-      ),
+      width: 110,
+      render: (level: unknown) => {
+        const riskLevel = String(level ?? '');
+        return (
+          <Chip
+            size="small"
+            label={formatRiskLevel(riskLevel)}
+            sx={{
+              color: RISK_LEVEL_COLORS[riskLevel] || 'text.primary',
+              borderColor: RISK_LEVEL_COLORS[riskLevel] || 'divider',
+              bgcolor: 'transparent',
+            }}
+            variant="outlined"
+          />
+        );
+      },
     },
     {
       title: '状态',
       dataIndex: 'status',
-      width: 100,
-      render: (status: string) => (
-        <Tag color={ALERT_STATUS_COLORS[status]}>{formatAlertStatus(status)}</Tag>
-      ),
+      width: 110,
+      render: (status: unknown) => {
+        const alertStatus = String(status ?? '');
+        return (
+          <Chip
+            size="small"
+            label={formatAlertStatus(alertStatus)}
+            sx={{
+              color: ALERT_STATUS_COLORS[alertStatus] || 'text.primary',
+              borderColor: ALERT_STATUS_COLORS[alertStatus] || 'divider',
+              bgcolor: 'transparent',
+            }}
+            variant="outlined"
+          />
+        );
+      },
     },
     { title: '触发时间', dataIndex: 'triggered_at', render: formatDateTime, width: 170 },
     {
@@ -106,42 +152,47 @@ const AlertListPage: React.FC = () => {
       width: 280,
       fixed: 'right',
       render: (_, record) => (
-        <Space>
+        <Stack direction="row" spacing={0.5} flexWrap="wrap">
           <Button
-            type="link"
             size="small"
-            icon={<EyeOutlined />}
+            startIcon={<VisibilityRoundedIcon />}
             onClick={() => navigate(`/alerts/${record.id}`)}
           >
             详情
           </Button>
           <PermissionGuard permission="alert:update">
             {record.status === 'pending' && (
-              <Popconfirm
-                title="确认开始处理？"
-                onConfirm={() => handleStatusUpdate(record.id, 'processing')}
+              <Button
+                size="small"
+                color="primary"
+                startIcon={<ManageSearchRoundedIcon />}
+                onClick={() => handleStatusUpdate(record.id, 'processing')}
               >
-                <Button type="link" size="small">处理</Button>
-              </Popconfirm>
+                处理
+              </Button>
             )}
             {record.status === 'processing' && (
-              <Popconfirm
-                title="确认已解决？"
-                onConfirm={() => handleStatusUpdate(record.id, 'resolved')}
+              <Button
+                size="small"
+                color="success"
+                startIcon={<TaskAltRoundedIcon />}
+                onClick={() => handleStatusUpdate(record.id, 'resolved')}
               >
-                <Button type="link" size="small">解决</Button>
-              </Popconfirm>
+                解决
+              </Button>
             )}
             {(record.status === 'pending' || record.status === 'processing') && (
-              <Popconfirm
-                title="确认忽略？"
-                onConfirm={() => handleStatusUpdate(record.id, 'ignored')}
+              <Button
+                size="small"
+                color="inherit"
+                startIcon={<BlockRoundedIcon />}
+                onClick={() => handleStatusUpdate(record.id, 'ignored')}
               >
-                <Button type="link" size="small" danger>忽略</Button>
-              </Popconfirm>
+                忽略
+              </Button>
             )}
           </PermissionGuard>
-        </Space>
+        </Stack>
       ),
     },
   ];
@@ -161,42 +212,85 @@ const AlertListPage: React.FC = () => {
           onChange: setSelectedRowKeys,
         }}
         toolbar={
-          <Space wrap>
-            <Select
-              placeholder="状态"
-              allowClear
-              options={ALERT_STATUS_OPTIONS}
-              style={{ width: 120 }}
-              value={query.status || undefined}
-              onChange={(val) => setQuery((prev) => ({ ...prev, status: val }))}
+          <Stack direction={{ xs: 'column', md: 'row' }} spacing={1.5} flexWrap="wrap">
+            <FormControl size="small" sx={{ minWidth: 120 }}>
+              <InputLabel>状态</InputLabel>
+              <Select
+                label="状态"
+                value={query.status || ''}
+                onChange={(event) =>
+                  setQuery((prev) => ({ ...prev, status: event.target.value || undefined }))
+                }
+              >
+                <MenuItem value="">全部</MenuItem>
+                {ALERT_STATUS_OPTIONS.map((option) => (
+                  <MenuItem key={option.value} value={option.value}>
+                    {option.label}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+            <FormControl size="small" sx={{ minWidth: 120 }}>
+              <InputLabel>风险等级</InputLabel>
+              <Select
+                label="风险等级"
+                value={query.risk_level || ''}
+                onChange={(event) =>
+                  setQuery((prev) => ({ ...prev, risk_level: event.target.value || undefined }))
+                }
+              >
+                <MenuItem value="">全部</MenuItem>
+                {RISK_LEVEL_OPTIONS.map((option) => (
+                  <MenuItem key={option.value} value={option.value}>
+                    {option.label}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+            <TextField
+              label="开始日期"
+              type="date"
+              size="small"
+              value={query.date_start || ''}
+              onChange={(event) =>
+                setQuery((prev) => ({ ...prev, date_start: event.target.value || undefined }))
+              }
+              InputLabelProps={{ shrink: true }}
             />
-            <Select
-              placeholder="风险等级"
-              allowClear
-              options={RISK_LEVEL_OPTIONS}
-              style={{ width: 120 }}
-              value={query.risk_level || undefined}
-              onChange={(val) => setQuery((prev) => ({ ...prev, risk_level: val }))}
+            <TextField
+              label="结束日期"
+              type="date"
+              size="small"
+              value={query.date_end || ''}
+              onChange={(event) =>
+                setQuery((prev) => ({ ...prev, date_end: event.target.value || undefined }))
+              }
+              InputLabelProps={{ shrink: true }}
             />
-            <RangePicker
-              onChange={(dates) => {
-                setQuery((prev) => ({
-                  ...prev,
-                  date_start: dates?.[0]?.format('YYYY-MM-DD') || undefined,
-                  date_end: dates?.[1]?.format('YYYY-MM-DD') || undefined,
-                }));
-              }}
-            />
+            <Button
+              variant="outlined"
+              onClick={() => handleBatchStatus('resolved')}
+              disabled={selectedRowKeys.length === 0}
+            >
+              批量解决
+            </Button>
+            <Button
+              variant="outlined"
+              onClick={() => handleBatchStatus('ignored')}
+              disabled={selectedRowKeys.length === 0}
+            >
+              批量忽略
+            </Button>
             <PermissionGuard permission="alert:update">
-              <Button onClick={() => handleBatchStatus('resolved')}>批量解决</Button>
-              <Button onClick={() => handleBatchStatus('ignored')}>批量忽略</Button>
-            </PermissionGuard>
-            <PermissionGuard permission="alert:update">
-              <Button type="primary" icon={<PlusOutlined />} onClick={() => setFormVisible(true)}>
+              <Button
+                variant="contained"
+                startIcon={<AddRoundedIcon />}
+                onClick={() => setFormVisible(true)}
+              >
                 手动创建
               </Button>
             </PermissionGuard>
-          </Space>
+          </Stack>
         }
       />
 

--- a/frontend/src/pages/alerts/AlertListPage.tsx
+++ b/frontend/src/pages/alerts/AlertListPage.tsx
@@ -1,8 +1,21 @@
-import React, { useState, useCallback } from 'react';
-import { Button, Tag, Space, Select, DatePicker, Popconfirm, message } from 'antd';
-import { PlusOutlined, EyeOutlined } from '@ant-design/icons';
+import React, { useCallback, useState } from 'react';
+import {
+  Button,
+  Chip,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+  Stack,
+  TextField,
+} from '@mui/material';
+import AddRoundedIcon from '@mui/icons-material/AddRounded';
+import VisibilityRoundedIcon from '@mui/icons-material/VisibilityRounded';
+import ManageSearchRoundedIcon from '@mui/icons-material/ManageSearchRounded';
+import TaskAltRoundedIcon from '@mui/icons-material/TaskAltRounded';
+import BlockRoundedIcon from '@mui/icons-material/BlockRounded';
 import { useNavigate } from 'react-router-dom';
-import type { ColumnsType } from 'antd/es/table';
+import type { AppTableColumn } from '../../components/AppTable';
 import AppTable from '../../components/AppTable';
 import AppForm, { type FormFieldConfig } from '../../components/AppForm';
 import PermissionGuard from '../../components/PermissionGuard';
@@ -20,9 +33,8 @@ import {
   RISK_LEVEL_COLORS,
   ALERT_STATUS_COLORS,
 } from '../../utils/constants';
+import { message } from '../../utils/message';
 import type { Alert, AlertListQuery } from '../../types/alert';
-
-const { RangePicker } = DatePicker;
 
 const createFields: FormFieldConfig[] = [
   { name: 'elder_id', label: '老人ID', type: 'number', required: true },
@@ -51,9 +63,13 @@ const AlertListPage: React.FC = () => {
   const { data, loading, pagination, handleTableChange, refresh, handleSearch, query, setQuery } =
     useTable<Alert, AlertListQuery>(fetchFn);
 
-  const handleStatusUpdate = async (id: number, status: string) => {
+  const handleStatusUpdate = async (id: number, status: Alert['status']) => {
+    if (!window.confirm(`确认将该预警标记为${formatAlertStatus(status)}？`)) {
+      return;
+    }
+
     try {
-      await updateAlertStatus(id, { status: status as Alert['status'] });
+      await updateAlertStatus(id, { status });
       message.success('状态更新成功');
       refresh();
     } catch (err) {
@@ -66,6 +82,11 @@ const AlertListPage: React.FC = () => {
       message.warning('请选择要处理的预警');
       return;
     }
+
+    if (!window.confirm(`确认将选中的预警批量标记为${formatAlertStatus(status)}？`)) {
+      return;
+    }
+
     try {
       await batchUpdateAlertStatus({
         ids: selectedRowKeys as number[],
@@ -80,68 +101,102 @@ const AlertListPage: React.FC = () => {
     }
   };
 
-  const columns: ColumnsType<Alert> = [
-    { title: '预警标题', dataIndex: 'title', width: 200 },
+  const columns: AppTableColumn<Alert>[] = [
+    { title: '预警标题', dataIndex: 'title', width: 220 },
     { title: '类型', dataIndex: 'type', width: 150 },
     {
       title: '风险等级',
       dataIndex: 'risk_level',
-      width: 100,
-      render: (level: string) => (
-        <Tag color={RISK_LEVEL_COLORS[level]}>{formatRiskLevel(level)}</Tag>
-      ),
+      width: 110,
+      render: (level: unknown) => {
+        const riskLevel = String(level ?? '');
+        return (
+          <Chip
+            size="small"
+            label={formatRiskLevel(riskLevel)}
+            sx={{
+              color: RISK_LEVEL_COLORS[riskLevel] || 'text.primary',
+              borderColor: RISK_LEVEL_COLORS[riskLevel] || 'divider',
+              bgcolor: 'transparent',
+            }}
+            variant="outlined"
+          />
+        );
+      },
     },
     {
       title: '状态',
       dataIndex: 'status',
-      width: 100,
-      render: (status: string) => (
-        <Tag color={ALERT_STATUS_COLORS[status]}>{formatAlertStatus(status)}</Tag>
-      ),
+      width: 110,
+      render: (status: unknown) => {
+        const alertStatus = String(status ?? '');
+        return (
+          <Chip
+            size="small"
+            label={formatAlertStatus(alertStatus)}
+            sx={{
+              color: ALERT_STATUS_COLORS[alertStatus] || 'text.primary',
+              borderColor: ALERT_STATUS_COLORS[alertStatus] || 'divider',
+              bgcolor: 'transparent',
+            }}
+            variant="outlined"
+          />
+        );
+      },
     },
-    { title: '触发时间', dataIndex: 'triggered_at', render: formatDateTime, width: 170 },
+    {
+      title: '触发时间',
+      dataIndex: 'triggered_at',
+      render: (value) => formatDateTime(value as string | null | undefined),
+      width: 170,
+    },
     {
       title: '操作',
       key: 'actions',
       width: 280,
       fixed: 'right',
       render: (_, record) => (
-        <Space>
+        <Stack direction="row" spacing={0.5} flexWrap="wrap">
           <Button
-            type="link"
             size="small"
-            icon={<EyeOutlined />}
+            startIcon={<VisibilityRoundedIcon />}
             onClick={() => navigate(`/alerts/${record.id}`)}
           >
             详情
           </Button>
           <PermissionGuard permission="alert:update">
             {record.status === 'pending' && (
-              <Popconfirm
-                title="确认开始处理？"
-                onConfirm={() => handleStatusUpdate(record.id, 'processing')}
+              <Button
+                size="small"
+                color="primary"
+                startIcon={<ManageSearchRoundedIcon />}
+                onClick={() => handleStatusUpdate(record.id, 'processing')}
               >
-                <Button type="link" size="small">处理</Button>
-              </Popconfirm>
+                处理
+              </Button>
             )}
             {record.status === 'processing' && (
-              <Popconfirm
-                title="确认已解决？"
-                onConfirm={() => handleStatusUpdate(record.id, 'resolved')}
+              <Button
+                size="small"
+                color="success"
+                startIcon={<TaskAltRoundedIcon />}
+                onClick={() => handleStatusUpdate(record.id, 'resolved')}
               >
-                <Button type="link" size="small">解决</Button>
-              </Popconfirm>
+                解决
+              </Button>
             )}
             {(record.status === 'pending' || record.status === 'processing') && (
-              <Popconfirm
-                title="确认忽略？"
-                onConfirm={() => handleStatusUpdate(record.id, 'ignored')}
+              <Button
+                size="small"
+                color="inherit"
+                startIcon={<BlockRoundedIcon />}
+                onClick={() => handleStatusUpdate(record.id, 'ignored')}
               >
-                <Button type="link" size="small" danger>忽略</Button>
-              </Popconfirm>
+                忽略
+              </Button>
             )}
           </PermissionGuard>
-        </Space>
+        </Stack>
       ),
     },
   ];
@@ -161,42 +216,85 @@ const AlertListPage: React.FC = () => {
           onChange: setSelectedRowKeys,
         }}
         toolbar={
-          <Space wrap>
-            <Select
-              placeholder="状态"
-              allowClear
-              options={ALERT_STATUS_OPTIONS}
-              style={{ width: 120 }}
-              value={query.status || undefined}
-              onChange={(val) => setQuery((prev) => ({ ...prev, status: val }))}
+          <Stack direction={{ xs: 'column', md: 'row' }} spacing={1.5} flexWrap="wrap">
+            <FormControl size="small" sx={{ minWidth: 120 }}>
+              <InputLabel>状态</InputLabel>
+              <Select
+                label="状态"
+                value={query.status || ''}
+                onChange={(event) =>
+                  setQuery((prev) => ({ ...prev, status: event.target.value || undefined }))
+                }
+              >
+                <MenuItem value="">全部</MenuItem>
+                {ALERT_STATUS_OPTIONS.map((option) => (
+                  <MenuItem key={option.value} value={option.value}>
+                    {option.label}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+            <FormControl size="small" sx={{ minWidth: 120 }}>
+              <InputLabel>风险等级</InputLabel>
+              <Select
+                label="风险等级"
+                value={query.risk_level || ''}
+                onChange={(event) =>
+                  setQuery((prev) => ({ ...prev, risk_level: event.target.value || undefined }))
+                }
+              >
+                <MenuItem value="">全部</MenuItem>
+                {RISK_LEVEL_OPTIONS.map((option) => (
+                  <MenuItem key={option.value} value={option.value}>
+                    {option.label}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+            <TextField
+              label="开始日期"
+              type="date"
+              size="small"
+              value={query.date_start || ''}
+              onChange={(event) =>
+                setQuery((prev) => ({ ...prev, date_start: event.target.value || undefined }))
+              }
+              InputLabelProps={{ shrink: true }}
             />
-            <Select
-              placeholder="风险等级"
-              allowClear
-              options={RISK_LEVEL_OPTIONS}
-              style={{ width: 120 }}
-              value={query.risk_level || undefined}
-              onChange={(val) => setQuery((prev) => ({ ...prev, risk_level: val }))}
+            <TextField
+              label="结束日期"
+              type="date"
+              size="small"
+              value={query.date_end || ''}
+              onChange={(event) =>
+                setQuery((prev) => ({ ...prev, date_end: event.target.value || undefined }))
+              }
+              InputLabelProps={{ shrink: true }}
             />
-            <RangePicker
-              onChange={(dates) => {
-                setQuery((prev) => ({
-                  ...prev,
-                  date_start: dates?.[0]?.format('YYYY-MM-DD') || undefined,
-                  date_end: dates?.[1]?.format('YYYY-MM-DD') || undefined,
-                }));
-              }}
-            />
+            <Button
+              variant="outlined"
+              onClick={() => handleBatchStatus('resolved')}
+              disabled={selectedRowKeys.length === 0}
+            >
+              批量解决
+            </Button>
+            <Button
+              variant="outlined"
+              onClick={() => handleBatchStatus('ignored')}
+              disabled={selectedRowKeys.length === 0}
+            >
+              批量忽略
+            </Button>
             <PermissionGuard permission="alert:update">
-              <Button onClick={() => handleBatchStatus('resolved')}>批量解决</Button>
-              <Button onClick={() => handleBatchStatus('ignored')}>批量忽略</Button>
-            </PermissionGuard>
-            <PermissionGuard permission="alert:update">
-              <Button type="primary" icon={<PlusOutlined />} onClick={() => setFormVisible(true)}>
+              <Button
+                variant="contained"
+                startIcon={<AddRoundedIcon />}
+                onClick={() => setFormVisible(true)}
+              >
                 手动创建
               </Button>
             </PermissionGuard>
-          </Space>
+          </Stack>
         }
       />
 

--- a/frontend/src/pages/alerts/AlertListPage.tsx
+++ b/frontend/src/pages/alerts/AlertListPage.tsx
@@ -34,7 +34,6 @@ import {
   ALERT_STATUS_COLORS,
 } from '../../utils/constants';
 import { message } from '../../utils/message';
-import { useNavigate } from 'react-router-dom';
 import type { Alert, AlertListQuery } from '../../types/alert';
 
 const createFields: FormFieldConfig[] = [

--- a/frontend/src/pages/assessments/AssessmentPage.tsx
+++ b/frontend/src/pages/assessments/AssessmentPage.tsx
@@ -1,7 +1,23 @@
 import React, { useState, useCallback } from 'react';
-import { Button, Tag, Space, Select, DatePicker, Popconfirm, Modal, Form, InputNumber, message } from 'antd';
-import { PlusOutlined, ThunderboltOutlined, DeleteOutlined } from '@ant-design/icons';
-import type { ColumnsType } from 'antd/es/table';
+import {
+  Button,
+  Chip,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+  Stack,
+  TextField,
+} from '@mui/material';
+import AddRoundedIcon from '@mui/icons-material/AddRounded';
+import BoltRoundedIcon from '@mui/icons-material/BoltRounded';
+import EditRoundedIcon from '@mui/icons-material/EditRounded';
+import DeleteRoundedIcon from '@mui/icons-material/DeleteRounded';
+import type { AppTableColumn } from '../../components/AppTable';
 import AppTable from '../../components/AppTable';
 import AppForm, { type FormFieldConfig } from '../../components/AppForm';
 import PermissionGuard from '../../components/PermissionGuard';
@@ -15,9 +31,8 @@ import {
 } from '../../api/assessments';
 import { formatDateTime, formatRiskLevel } from '../../utils/formatter';
 import { RISK_LEVEL_OPTIONS, RISK_LEVEL_COLORS } from '../../utils/constants';
+import { message } from '../../utils/message';
 import type { Assessment, AssessmentListQuery } from '../../types/assessment';
-
-const { RangePicker } = DatePicker;
 
 const ASSESSMENT_TYPE_OPTIONS = [
   { label: '综合评估', value: 'comprehensive' },
@@ -38,7 +53,7 @@ const AssessmentPage: React.FC = () => {
   const [formVisible, setFormVisible] = useState(false);
   const [editingItem, setEditingItem] = useState<Assessment | null>(null);
   const [generateModalVisible, setGenerateModalVisible] = useState(false);
-  const [generateForm] = Form.useForm();
+  const [generateElderId, setGenerateElderId] = useState('');
   const [generateLoading, setGenerateLoading] = useState(false);
 
   const fetchFn = useCallback(
@@ -60,6 +75,10 @@ const AssessmentPage: React.FC = () => {
   };
 
   const handleDelete = async (id: number) => {
+    if (!window.confirm('确定删除该评估记录？')) {
+      return;
+    }
+
     try {
       await deleteAssessment(id);
       message.success('删除成功');
@@ -70,25 +89,30 @@ const AssessmentPage: React.FC = () => {
   };
 
   const handleGenerate = async () => {
+    const elderId = Number(generateElderId);
+    if (!Number.isFinite(elderId) || elderId <= 0) {
+      message.warning('请输入有效的老人ID');
+      return;
+    }
+
     try {
-      const values = await generateForm.validateFields();
       setGenerateLoading(true);
       await generateAssessment({
-        elder_id: values.elder_id,
+        elder_id: elderId,
         force_recalculate: true,
       });
       message.success('评估生成成功');
       setGenerateModalVisible(false);
-      generateForm.resetFields();
+      setGenerateElderId('');
       refresh();
     } catch (err) {
-      if (err instanceof Error) message.error(err.message);
+      message.error(err instanceof Error ? err.message : '生成失败');
     } finally {
       setGenerateLoading(false);
     }
   };
 
-  const columns: ColumnsType<Assessment> = [
+  const columns: AppTableColumn<Assessment>[] = [
     { title: '老人ID', dataIndex: 'elder_id', width: 80 },
     { title: '老人姓名', dataIndex: 'elder_name', width: 100 },
     { title: '评估类型', dataIndex: 'assessment_type', width: 120 },
@@ -97,32 +121,54 @@ const AssessmentPage: React.FC = () => {
       title: '风险等级',
       dataIndex: 'risk_level',
       width: 100,
-      render: (level: string) => (
-        <Tag color={RISK_LEVEL_COLORS[level]}>{formatRiskLevel(level)}</Tag>
-      ),
+      render: (level: unknown) => {
+        const riskLevel = String(level ?? '');
+        return (
+          <Chip
+            size="small"
+            label={formatRiskLevel(riskLevel)}
+            sx={{
+              color: RISK_LEVEL_COLORS[riskLevel] || 'text.primary',
+              borderColor: RISK_LEVEL_COLORS[riskLevel] || 'divider',
+              bgcolor: 'transparent',
+            }}
+            variant="outlined"
+          />
+        );
+      },
     },
     { title: '评估摘要', dataIndex: 'summary', ellipsis: true },
-    { title: '创建时间', dataIndex: 'created_at', render: formatDateTime, width: 170 },
+    {
+      title: '创建时间',
+      dataIndex: 'created_at',
+      render: (value) => formatDateTime(value as string | null | undefined),
+      width: 170,
+    },
     {
       title: '操作',
       key: 'actions',
       width: 180,
       fixed: 'right',
       render: (_, record) => (
-        <Space>
+        <Stack direction="row" spacing={0.5} flexWrap="wrap">
           <PermissionGuard permission="assessment:create">
-            <Button type="link" size="small" onClick={() => handleEdit(record)}>
+            <Button
+              size="small"
+              startIcon={<EditRoundedIcon />}
+              onClick={() => handleEdit(record)}
+            >
               编辑
             </Button>
+            <Button
+              size="small"
+              color="inherit"
+              startIcon={<DeleteRoundedIcon />}
+              onClick={() => handleDelete(record.id)}
+            >
+              删除
+            </Button>
           </PermissionGuard>
-          <PermissionGuard permission="assessment:create">
-            <Popconfirm title="确定删除？" onConfirm={() => handleDelete(record.id)}>
-              <Button type="link" size="small" danger icon={<DeleteOutlined />}>
-                删除
-              </Button>
-            </Popconfirm>
-          </PermissionGuard>
-        </Space>
+        </Stack>
       ),
     },
   ];
@@ -138,44 +184,74 @@ const AssessmentPage: React.FC = () => {
         onSearch={handleSearch}
         searchPlaceholder="搜索评估"
         toolbar={
-          <Space wrap>
-            <Select
-              placeholder="风险等级"
-              allowClear
-              options={RISK_LEVEL_OPTIONS}
-              style={{ width: 120 }}
-              value={query.risk_level || undefined}
-              onChange={(val) => setQuery((prev) => ({ ...prev, risk_level: val }))}
+          <Stack direction={{ xs: 'column', md: 'row' }} spacing={1.5} flexWrap="wrap">
+            <FormControl size="small" sx={{ minWidth: 120 }}>
+              <InputLabel>风险等级</InputLabel>
+              <Select
+                label="风险等级"
+                value={query.risk_level || ''}
+                onChange={(event) =>
+                  setQuery((prev) => ({ ...prev, risk_level: event.target.value || undefined }))
+                }
+              >
+                <MenuItem value="">全部</MenuItem>
+                {RISK_LEVEL_OPTIONS.map((option) => (
+                  <MenuItem key={option.value} value={option.value}>
+                    {option.label}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+            <FormControl size="small" sx={{ minWidth: 140 }}>
+              <InputLabel>评估类型</InputLabel>
+              <Select
+                label="评估类型"
+                value={query.assessment_type || ''}
+                onChange={(event) =>
+                  setQuery((prev) => ({ ...prev, assessment_type: event.target.value || undefined }))
+                }
+              >
+                <MenuItem value="">全部</MenuItem>
+                {ASSESSMENT_TYPE_OPTIONS.map((option) => (
+                  <MenuItem key={option.value} value={option.value}>
+                    {option.label}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+            <TextField
+              label="开始日期"
+              type="date"
+              size="small"
+              value={query.date_start || ''}
+              onChange={(event) =>
+                setQuery((prev) => ({ ...prev, date_start: event.target.value || undefined }))
+              }
+              InputLabelProps={{ shrink: true }}
             />
-            <Select
-              placeholder="评估类型"
-              allowClear
-              options={ASSESSMENT_TYPE_OPTIONS}
-              style={{ width: 120 }}
-              value={query.assessment_type || undefined}
-              onChange={(val) => setQuery((prev) => ({ ...prev, assessment_type: val }))}
-            />
-            <RangePicker
-              onChange={(dates) => {
-                setQuery((prev) => ({
-                  ...prev,
-                  date_start: dates?.[0]?.format('YYYY-MM-DD') || undefined,
-                  date_end: dates?.[1]?.format('YYYY-MM-DD') || undefined,
-                }));
-              }}
+            <TextField
+              label="结束日期"
+              type="date"
+              size="small"
+              value={query.date_end || ''}
+              onChange={(event) =>
+                setQuery((prev) => ({ ...prev, date_end: event.target.value || undefined }))
+              }
+              InputLabelProps={{ shrink: true }}
             />
             <PermissionGuard permission="assessment:create">
               <Button
-                icon={<ThunderboltOutlined />}
+                variant="outlined"
+                startIcon={<BoltRoundedIcon />}
                 onClick={() => setGenerateModalVisible(true)}
               >
                 自动生成评估
               </Button>
-              <Button type="primary" icon={<PlusOutlined />} onClick={handleCreate}>
+              <Button variant="contained" startIcon={<AddRoundedIcon />} onClick={handleCreate}>
                 新建评估
               </Button>
             </PermissionGuard>
-          </Space>
+          </Stack>
         }
       />
 
@@ -197,26 +273,41 @@ const AssessmentPage: React.FC = () => {
         onCancel={() => setFormVisible(false)}
       />
 
-      <Modal
-        title="自动生成评估"
+      <Dialog
         open={generateModalVisible}
-        onOk={handleGenerate}
-        onCancel={() => {
+        onClose={() => {
           setGenerateModalVisible(false);
-          generateForm.resetFields();
+          setGenerateElderId('');
         }}
-        confirmLoading={generateLoading}
+        fullWidth
+        maxWidth="sm"
       >
-        <Form form={generateForm} layout="vertical">
-          <Form.Item
-            name="elder_id"
+        <DialogTitle>自动生成评估</DialogTitle>
+        <DialogContent>
+          <TextField
             label="老人ID"
-            rules={[{ required: true, message: '请输入老人ID' }]}
+            value={generateElderId}
+            onChange={(event) => setGenerateElderId(event.target.value)}
+            fullWidth
+            sx={{ mt: 1 }}
+            placeholder="请输入老人ID"
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button
+            color="inherit"
+            onClick={() => {
+              setGenerateModalVisible(false);
+              setGenerateElderId('');
+            }}
           >
-            <InputNumber style={{ width: '100%' }} placeholder="请输入老人ID" />
-          </Form.Item>
-        </Form>
-      </Modal>
+            取消
+          </Button>
+          <Button variant="contained" onClick={handleGenerate} disabled={generateLoading}>
+            {generateLoading ? '生成中...' : '确定'}
+          </Button>
+        </DialogActions>
+      </Dialog>
     </>
   );
 };

--- a/frontend/src/pages/assessments/AssessmentPage.tsx
+++ b/frontend/src/pages/assessments/AssessmentPage.tsx
@@ -1,7 +1,23 @@
 import React, { useState, useCallback } from 'react';
-import { Button, Tag, Space, Select, DatePicker, Popconfirm, Modal, Form, InputNumber, message } from 'antd';
-import { PlusOutlined, ThunderboltOutlined, DeleteOutlined } from '@ant-design/icons';
-import type { ColumnsType } from 'antd/es/table';
+import {
+  Button,
+  Chip,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+  Stack,
+  TextField,
+} from '@mui/material';
+import AddRoundedIcon from '@mui/icons-material/AddRounded';
+import BoltRoundedIcon from '@mui/icons-material/BoltRounded';
+import EditRoundedIcon from '@mui/icons-material/EditRounded';
+import DeleteRoundedIcon from '@mui/icons-material/DeleteRounded';
+import type { AppTableColumn } from '../../components/AppTable';
 import AppTable from '../../components/AppTable';
 import AppForm, { type FormFieldConfig } from '../../components/AppForm';
 import PermissionGuard from '../../components/PermissionGuard';
@@ -15,9 +31,8 @@ import {
 } from '../../api/assessments';
 import { formatDateTime, formatRiskLevel } from '../../utils/formatter';
 import { RISK_LEVEL_OPTIONS, RISK_LEVEL_COLORS } from '../../utils/constants';
+import { message } from '../../utils/message';
 import type { Assessment, AssessmentListQuery } from '../../types/assessment';
-
-const { RangePicker } = DatePicker;
 
 const ASSESSMENT_TYPE_OPTIONS = [
   { label: '综合评估', value: 'comprehensive' },
@@ -38,7 +53,7 @@ const AssessmentPage: React.FC = () => {
   const [formVisible, setFormVisible] = useState(false);
   const [editingItem, setEditingItem] = useState<Assessment | null>(null);
   const [generateModalVisible, setGenerateModalVisible] = useState(false);
-  const [generateForm] = Form.useForm();
+  const [generateElderId, setGenerateElderId] = useState('');
   const [generateLoading, setGenerateLoading] = useState(false);
 
   const fetchFn = useCallback(
@@ -60,6 +75,10 @@ const AssessmentPage: React.FC = () => {
   };
 
   const handleDelete = async (id: number) => {
+    if (!window.confirm('确定删除该评估记录？')) {
+      return;
+    }
+
     try {
       await deleteAssessment(id);
       message.success('删除成功');
@@ -70,25 +89,30 @@ const AssessmentPage: React.FC = () => {
   };
 
   const handleGenerate = async () => {
+    const elderId = Number(generateElderId);
+    if (!Number.isFinite(elderId) || elderId <= 0) {
+      message.warning('请输入有效的老人ID');
+      return;
+    }
+
     try {
-      const values = await generateForm.validateFields();
       setGenerateLoading(true);
       await generateAssessment({
-        elder_id: values.elder_id,
+        elder_id: elderId,
         force_recalculate: true,
       });
       message.success('评估生成成功');
       setGenerateModalVisible(false);
-      generateForm.resetFields();
+      setGenerateElderId('');
       refresh();
     } catch (err) {
-      if (err instanceof Error) message.error(err.message);
+      message.error(err instanceof Error ? err.message : '生成失败');
     } finally {
       setGenerateLoading(false);
     }
   };
 
-  const columns: ColumnsType<Assessment> = [
+  const columns: AppTableColumn<Assessment>[] = [
     { title: '老人ID', dataIndex: 'elder_id', width: 80 },
     { title: '老人姓名', dataIndex: 'elder_name', width: 100 },
     { title: '评估类型', dataIndex: 'assessment_type', width: 120 },
@@ -97,9 +121,21 @@ const AssessmentPage: React.FC = () => {
       title: '风险等级',
       dataIndex: 'risk_level',
       width: 100,
-      render: (level: string) => (
-        <Tag color={RISK_LEVEL_COLORS[level]}>{formatRiskLevel(level)}</Tag>
-      ),
+      render: (level: unknown) => {
+        const riskLevel = String(level ?? '');
+        return (
+          <Chip
+            size="small"
+            label={formatRiskLevel(riskLevel)}
+            sx={{
+              color: RISK_LEVEL_COLORS[riskLevel] || 'text.primary',
+              borderColor: RISK_LEVEL_COLORS[riskLevel] || 'divider',
+              bgcolor: 'transparent',
+            }}
+            variant="outlined"
+          />
+        );
+      },
     },
     { title: '评估摘要', dataIndex: 'summary', ellipsis: true },
     { title: '创建时间', dataIndex: 'created_at', render: formatDateTime, width: 170 },
@@ -109,20 +145,25 @@ const AssessmentPage: React.FC = () => {
       width: 180,
       fixed: 'right',
       render: (_, record) => (
-        <Space>
+        <Stack direction="row" spacing={0.5} flexWrap="wrap">
           <PermissionGuard permission="assessment:create">
-            <Button type="link" size="small" onClick={() => handleEdit(record)}>
+            <Button
+              size="small"
+              startIcon={<EditRoundedIcon />}
+              onClick={() => handleEdit(record)}
+            >
               编辑
             </Button>
+            <Button
+              size="small"
+              color="inherit"
+              startIcon={<DeleteRoundedIcon />}
+              onClick={() => handleDelete(record.id)}
+            >
+              删除
+            </Button>
           </PermissionGuard>
-          <PermissionGuard permission="assessment:create">
-            <Popconfirm title="确定删除？" onConfirm={() => handleDelete(record.id)}>
-              <Button type="link" size="small" danger icon={<DeleteOutlined />}>
-                删除
-              </Button>
-            </Popconfirm>
-          </PermissionGuard>
-        </Space>
+        </Stack>
       ),
     },
   ];
@@ -138,44 +179,74 @@ const AssessmentPage: React.FC = () => {
         onSearch={handleSearch}
         searchPlaceholder="搜索评估"
         toolbar={
-          <Space wrap>
-            <Select
-              placeholder="风险等级"
-              allowClear
-              options={RISK_LEVEL_OPTIONS}
-              style={{ width: 120 }}
-              value={query.risk_level || undefined}
-              onChange={(val) => setQuery((prev) => ({ ...prev, risk_level: val }))}
+          <Stack direction={{ xs: 'column', md: 'row' }} spacing={1.5} flexWrap="wrap">
+            <FormControl size="small" sx={{ minWidth: 120 }}>
+              <InputLabel>风险等级</InputLabel>
+              <Select
+                label="风险等级"
+                value={query.risk_level || ''}
+                onChange={(event) =>
+                  setQuery((prev) => ({ ...prev, risk_level: event.target.value || undefined }))
+                }
+              >
+                <MenuItem value="">全部</MenuItem>
+                {RISK_LEVEL_OPTIONS.map((option) => (
+                  <MenuItem key={option.value} value={option.value}>
+                    {option.label}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+            <FormControl size="small" sx={{ minWidth: 140 }}>
+              <InputLabel>评估类型</InputLabel>
+              <Select
+                label="评估类型"
+                value={query.assessment_type || ''}
+                onChange={(event) =>
+                  setQuery((prev) => ({ ...prev, assessment_type: event.target.value || undefined }))
+                }
+              >
+                <MenuItem value="">全部</MenuItem>
+                {ASSESSMENT_TYPE_OPTIONS.map((option) => (
+                  <MenuItem key={option.value} value={option.value}>
+                    {option.label}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+            <TextField
+              label="开始日期"
+              type="date"
+              size="small"
+              value={query.date_start || ''}
+              onChange={(event) =>
+                setQuery((prev) => ({ ...prev, date_start: event.target.value || undefined }))
+              }
+              InputLabelProps={{ shrink: true }}
             />
-            <Select
-              placeholder="评估类型"
-              allowClear
-              options={ASSESSMENT_TYPE_OPTIONS}
-              style={{ width: 120 }}
-              value={query.assessment_type || undefined}
-              onChange={(val) => setQuery((prev) => ({ ...prev, assessment_type: val }))}
-            />
-            <RangePicker
-              onChange={(dates) => {
-                setQuery((prev) => ({
-                  ...prev,
-                  date_start: dates?.[0]?.format('YYYY-MM-DD') || undefined,
-                  date_end: dates?.[1]?.format('YYYY-MM-DD') || undefined,
-                }));
-              }}
+            <TextField
+              label="结束日期"
+              type="date"
+              size="small"
+              value={query.date_end || ''}
+              onChange={(event) =>
+                setQuery((prev) => ({ ...prev, date_end: event.target.value || undefined }))
+              }
+              InputLabelProps={{ shrink: true }}
             />
             <PermissionGuard permission="assessment:create">
               <Button
-                icon={<ThunderboltOutlined />}
+                variant="outlined"
+                startIcon={<BoltRoundedIcon />}
                 onClick={() => setGenerateModalVisible(true)}
               >
                 自动生成评估
               </Button>
-              <Button type="primary" icon={<PlusOutlined />} onClick={handleCreate}>
+              <Button variant="contained" startIcon={<AddRoundedIcon />} onClick={handleCreate}>
                 新建评估
               </Button>
             </PermissionGuard>
-          </Space>
+          </Stack>
         }
       />
 
@@ -197,26 +268,41 @@ const AssessmentPage: React.FC = () => {
         onCancel={() => setFormVisible(false)}
       />
 
-      <Modal
-        title="自动生成评估"
+      <Dialog
         open={generateModalVisible}
-        onOk={handleGenerate}
-        onCancel={() => {
+        onClose={() => {
           setGenerateModalVisible(false);
-          generateForm.resetFields();
+          setGenerateElderId('');
         }}
-        confirmLoading={generateLoading}
+        fullWidth
+        maxWidth="sm"
       >
-        <Form form={generateForm} layout="vertical">
-          <Form.Item
-            name="elder_id"
+        <DialogTitle>自动生成评估</DialogTitle>
+        <DialogContent>
+          <TextField
             label="老人ID"
-            rules={[{ required: true, message: '请输入老人ID' }]}
+            value={generateElderId}
+            onChange={(event) => setGenerateElderId(event.target.value)}
+            fullWidth
+            sx={{ mt: 1 }}
+            placeholder="请输入老人ID"
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button
+            color="inherit"
+            onClick={() => {
+              setGenerateModalVisible(false);
+              setGenerateElderId('');
+            }}
           >
-            <InputNumber style={{ width: '100%' }} placeholder="请输入老人ID" />
-          </Form.Item>
-        </Form>
-      </Modal>
+            取消
+          </Button>
+          <Button variant="contained" onClick={handleGenerate} disabled={generateLoading}>
+            {generateLoading ? '生成中...' : '确定'}
+          </Button>
+        </DialogActions>
+      </Dialog>
     </>
   );
 };

--- a/frontend/src/pages/dashboard/DashboardPage.tsx
+++ b/frontend/src/pages/dashboard/DashboardPage.tsx
@@ -1,17 +1,31 @@
 import React, { useEffect, useState, useCallback } from 'react';
-import { Row, Col, Card, List, Tag, Select, message } from 'antd';
 import {
-  TeamOutlined,
-  AlertOutlined,
-  ScheduleOutlined,
-  CheckCircleOutlined,
-  WarningOutlined,
-  FileSearchOutlined,
-} from '@ant-design/icons';
+  Box,
+  Card,
+  CardContent,
+  Chip,
+  FormControl,
+  Grid,
+  InputLabel,
+  List,
+  ListItem,
+  ListItemText,
+  MenuItem,
+  Select,
+  Stack,
+  Typography,
+} from '@mui/material';
+import GroupsRoundedIcon from '@mui/icons-material/GroupsRounded';
+import WarningAmberRoundedIcon from '@mui/icons-material/WarningAmberRounded';
+import PendingActionsRoundedIcon from '@mui/icons-material/PendingActionsRounded';
+import CheckCircleRoundedIcon from '@mui/icons-material/CheckCircleRounded';
+import SickRoundedIcon from '@mui/icons-material/SickRounded';
+import AssessmentRoundedIcon from '@mui/icons-material/AssessmentRounded';
 import ReactECharts from 'echarts-for-react';
 import StatCard from '../../components/StatCard';
 import { getOverview, getTodos, getTrends } from '../../api/dashboard';
 import type { DashboardOverview, TodoItem, TrendData } from '../../api/dashboard';
+import { message } from '../../utils/message';
 
 const DashboardPage: React.FC = () => {
   const [overview, setOverview] = useState<DashboardOverview | null>(null);
@@ -57,109 +71,166 @@ const DashboardPage: React.FC = () => {
       }
     : {};
 
+  const todoPriorityColor: Record<string, 'default' | 'primary' | 'warning' | 'error'> = {
+    low: 'default',
+    medium: 'primary',
+    high: 'warning',
+    urgent: 'error',
+  };
+
   return (
-    <div>
-      <Row gutter={[16, 16]}>
-        <Col xs={24} sm={12} lg={4}>
+    <Box sx={{ display: 'grid', gap: 2 }}>
+      <Grid container spacing={2}>
+        <Grid item xs={12} sm={6} lg={4}>
           <StatCard
             title="老人总数"
             value={overview?.elder_total ?? '-'}
-            icon={<TeamOutlined />}
-            color="#1677ff"
+            icon={<GroupsRoundedIcon />}
+            color="#1f6feb"
             loading={loading}
           />
-        </Col>
-        <Col xs={24} sm={12} lg={4}>
+        </Grid>
+        <Grid item xs={12} sm={6} lg={4}>
           <StatCard
             title="高风险人数"
             value={overview?.high_risk_total ?? '-'}
-            icon={<WarningOutlined />}
-            color="#ff4d4f"
+            icon={<WarningAmberRoundedIcon />}
+            color="#d14343"
             loading={loading}
           />
-        </Col>
-        <Col xs={24} sm={12} lg={4}>
+        </Grid>
+        <Grid item xs={12} sm={6} lg={4}>
           <StatCard
             title="待处理预警"
             value={overview?.pending_alert_total ?? '-'}
-            icon={<AlertOutlined />}
-            color="#faad14"
+            icon={<PendingActionsRoundedIcon />}
+            color="#d9822b"
             loading={loading}
           />
-        </Col>
-        <Col xs={24} sm={12} lg={4}>
+        </Grid>
+        <Grid item xs={12} sm={6} lg={4}>
           <StatCard
             title="待随访任务"
             value={overview?.todo_followup_total ?? '-'}
-            icon={<ScheduleOutlined />}
-            color="#722ed1"
+            icon={<SickRoundedIcon />}
+            color="#0f9d8f"
             loading={loading}
           />
-        </Col>
-        <Col xs={24} sm={12} lg={4}>
+        </Grid>
+        <Grid item xs={12} sm={6} lg={4}>
           <StatCard
             title="今日已完成随访"
             value={overview?.completed_followup_today ?? '-'}
-            icon={<CheckCircleOutlined />}
-            color="#52c41a"
+            icon={<CheckCircleRoundedIcon />}
+            color="#1f9d63"
             loading={loading}
           />
-        </Col>
-        <Col xs={24} sm={12} lg={4}>
+        </Grid>
+        <Grid item xs={12} sm={6} lg={4}>
           <StatCard
             title="今日评估数"
             value={overview?.assessment_total_today ?? '-'}
-            icon={<FileSearchOutlined />}
+            icon={<AssessmentRoundedIcon />}
             color="#13c2c2"
             loading={loading}
           />
-        </Col>
-      </Row>
+        </Grid>
+      </Grid>
 
-      <Row gutter={[16, 16]} style={{ marginTop: 16 }}>
-        <Col xs={24} lg={16}>
-          <Card
-            title="趋势数据"
-            extra={
-              <Select
-                value={trendRange}
-                onChange={setTrendRange}
-                options={[
-                  { label: '近7天', value: '7d' },
-                  { label: '近30天', value: '30d' },
-                  { label: '近90天', value: '90d' },
-                ]}
-                style={{ width: 100 }}
-              />
-            }
-          >
-            {trends && <ReactECharts option={chartOption} style={{ height: 350 }} />}
-          </Card>
-        </Col>
-        <Col xs={24} lg={8}>
-          <Card title="近期待办" style={{ height: '100%' }}>
-            <List
-              loading={loading}
-              dataSource={todos}
-              renderItem={(item) => (
-                <List.Item>
-                  <List.Item.Meta
-                    title={
-                      <span>
-                        <Tag color="blue">{item.type}</Tag>
-                        {item.title}
-                      </span>
-                    }
-                    description={item.description}
-                  />
-                </List.Item>
+      <Grid container spacing={2}>
+        <Grid item xs={12} lg={8}>
+          <Card sx={{ height: '100%' }}>
+            <CardContent>
+              <Stack
+                direction={{ xs: 'column', sm: 'row' }}
+                justifyContent="space-between"
+                spacing={2}
+                sx={{ mb: 2 }}
+              >
+                <Box>
+                  <Typography variant="h6">趋势数据</Typography>
+                  <Typography variant="body2" color="text.secondary">
+                    近期开奖、随访和评估的变化趋势
+                  </Typography>
+                </Box>
+                <FormControl size="small" sx={{ minWidth: 140 }}>
+                  <InputLabel>时间范围</InputLabel>
+                  <Select
+                    label="时间范围"
+                    value={trendRange}
+                    onChange={(event) => setTrendRange(event.target.value)}
+                  >
+                    <MenuItem value="7d">近7天</MenuItem>
+                    <MenuItem value="30d">近30天</MenuItem>
+                    <MenuItem value="90d">近90天</MenuItem>
+                  </Select>
+                </FormControl>
+              </Stack>
+              {trends ? (
+                <ReactECharts option={chartOption} style={{ height: 350 }} />
+              ) : (
+                <Typography color="text.secondary" sx={{ py: 6, textAlign: 'center' }}>
+                  暂无趋势数据
+                </Typography>
               )}
-              locale={{ emptyText: '暂无待办事项' }}
-            />
+            </CardContent>
           </Card>
-        </Col>
-      </Row>
-    </div>
+        </Grid>
+        <Grid item xs={12} lg={4}>
+          <Card sx={{ height: '100%' }}>
+            <CardContent>
+              <Typography variant="h6" sx={{ mb: 1 }}>
+                近期待办
+              </Typography>
+              <List disablePadding>
+                {todos.map((item) => (
+                  <ListItem
+                    key={item.id}
+                    divider
+                    disableGutters
+                    sx={{ py: 1.25, alignItems: 'flex-start' }}
+                  >
+                    <ListItemText
+                      primary={
+                        <Stack
+                          direction="row"
+                          spacing={1}
+                          alignItems="center"
+                          flexWrap="wrap"
+                          sx={{ mb: 0.5 }}
+                        >
+                          <Chip label={item.type} size="small" variant="outlined" />
+                          <Chip
+                            label={item.priority}
+                            size="small"
+                            color={todoPriorityColor[item.priority] || 'default'}
+                          />
+                        </Stack>
+                      }
+                      secondary={
+                        <>
+                          <Typography component="span" variant="body2" color="text.primary">
+                            {item.title}
+                          </Typography>
+                          <Typography component="span" variant="body2" display="block">
+                            {item.description}
+                          </Typography>
+                        </>
+                      }
+                    />
+                  </ListItem>
+                ))}
+                {!loading && todos.length === 0 && (
+                  <Typography color="text.secondary" sx={{ py: 4, textAlign: 'center' }}>
+                    暂无待办事项
+                  </Typography>
+                )}
+              </List>
+            </CardContent>
+          </Card>
+        </Grid>
+      </Grid>
+    </Box>
   );
 };
 

--- a/frontend/src/pages/dashboard/DashboardPage.tsx
+++ b/frontend/src/pages/dashboard/DashboardPage.tsx
@@ -1,17 +1,30 @@
-import React, { useEffect, useState, useCallback } from 'react';
-import { Row, Col, Card, List, Tag, Select, message } from 'antd';
+import React, { useEffect, useMemo, useState, useCallback } from 'react';
 import {
-  TeamOutlined,
-  AlertOutlined,
-  ScheduleOutlined,
-  CheckCircleOutlined,
-  WarningOutlined,
-  FileSearchOutlined,
-} from '@ant-design/icons';
+  Box,
+  Card,
+  CardContent,
+  Chip,
+  FormControl,
+  InputLabel,
+  List,
+  ListItem,
+  ListItemText,
+  MenuItem,
+  Select,
+  Stack,
+  Typography,
+} from '@mui/material';
+import GroupsRoundedIcon from '@mui/icons-material/GroupsRounded';
+import WarningAmberRoundedIcon from '@mui/icons-material/WarningAmberRounded';
+import PendingActionsRoundedIcon from '@mui/icons-material/PendingActionsRounded';
+import CheckCircleRoundedIcon from '@mui/icons-material/CheckCircleRounded';
+import LocalHospitalRoundedIcon from '@mui/icons-material/LocalHospitalRounded';
+import InsightsRoundedIcon from '@mui/icons-material/InsightsRounded';
 import ReactECharts from 'echarts-for-react';
 import StatCard from '../../components/StatCard';
 import { getOverview, getTodos, getTrends } from '../../api/dashboard';
 import type { DashboardOverview, TodoItem, TrendData } from '../../api/dashboard';
+import { message } from '../../utils/message';
 
 const DashboardPage: React.FC = () => {
   const [overview, setOverview] = useState<DashboardOverview | null>(null);
@@ -42,124 +55,145 @@ const DashboardPage: React.FC = () => {
     fetchData();
   }, [fetchData]);
 
-  const chartOption = trends
-    ? {
-        tooltip: { trigger: 'axis' as const },
-        legend: { data: ['预警数', '随访数', '评估数'] },
-        grid: { left: '3%', right: '4%', bottom: '3%', containLabel: true },
-        xAxis: { type: 'category' as const, data: trends.dates },
-        yAxis: { type: 'value' as const },
-        series: [
-          { name: '预警数', type: 'line', data: trends.alerts, smooth: true },
-          { name: '随访数', type: 'line', data: trends.followups, smooth: true },
-          { name: '评估数', type: 'line', data: trends.assessments, smooth: true },
-        ],
-      }
-    : {};
+  const chartOption = useMemo(
+    () =>
+      trends
+        ? {
+            tooltip: { trigger: 'axis' as const },
+            legend: { data: ['预警数', '随访数', '评估数'] },
+            grid: { left: '3%', right: '4%', bottom: '3%', containLabel: true },
+            xAxis: { type: 'category' as const, data: trends.dates },
+            yAxis: { type: 'value' as const },
+            series: [
+              { name: '预警数', type: 'line', data: trends.alerts, smooth: true },
+              { name: '随访数', type: 'line', data: trends.followups, smooth: true },
+              { name: '评估数', type: 'line', data: trends.assessments, smooth: true },
+            ],
+          }
+        : {},
+    [trends],
+  );
+
+  const todoPriorityColor: Record<string, 'default' | 'primary' | 'warning' | 'error'> = {
+    low: 'default',
+    medium: 'primary',
+    high: 'warning',
+    urgent: 'error',
+  };
 
   return (
-    <div>
-      <Row gutter={[16, 16]}>
-        <Col xs={24} sm={12} lg={4}>
-          <StatCard
-            title="老人总数"
-            value={overview?.elder_total ?? '-'}
-            icon={<TeamOutlined />}
-            color="#1677ff"
-            loading={loading}
-          />
-        </Col>
-        <Col xs={24} sm={12} lg={4}>
-          <StatCard
-            title="高风险人数"
-            value={overview?.high_risk_total ?? '-'}
-            icon={<WarningOutlined />}
-            color="#ff4d4f"
-            loading={loading}
-          />
-        </Col>
-        <Col xs={24} sm={12} lg={4}>
-          <StatCard
-            title="待处理预警"
-            value={overview?.pending_alert_total ?? '-'}
-            icon={<AlertOutlined />}
-            color="#faad14"
-            loading={loading}
-          />
-        </Col>
-        <Col xs={24} sm={12} lg={4}>
-          <StatCard
-            title="待随访任务"
-            value={overview?.todo_followup_total ?? '-'}
-            icon={<ScheduleOutlined />}
-            color="#722ed1"
-            loading={loading}
-          />
-        </Col>
-        <Col xs={24} sm={12} lg={4}>
-          <StatCard
-            title="今日已完成随访"
-            value={overview?.completed_followup_today ?? '-'}
-            icon={<CheckCircleOutlined />}
-            color="#52c41a"
-            loading={loading}
-          />
-        </Col>
-        <Col xs={24} sm={12} lg={4}>
-          <StatCard
-            title="今日评估数"
-            value={overview?.assessment_total_today ?? '-'}
-            icon={<FileSearchOutlined />}
-            color="#13c2c2"
-            loading={loading}
-          />
-        </Col>
-      </Row>
+    <Box sx={{ display: 'grid', gap: 2 }}>
+      <Box
+        sx={{
+          display: 'grid',
+          gap: 2,
+          gridTemplateColumns: {
+            xs: '1fr',
+            sm: 'repeat(2, minmax(0, 1fr))',
+            lg: 'repeat(3, minmax(0, 1fr))',
+          },
+        }}
+      >
+        <StatCard title="老人总数" value={overview?.elder_total ?? '-'} icon={<GroupsRoundedIcon />} color="#1f6feb" loading={loading} />
+        <StatCard title="高风险人数" value={overview?.high_risk_total ?? '-'} icon={<WarningAmberRoundedIcon />} color="#d14343" loading={loading} />
+        <StatCard title="待处理预警" value={overview?.pending_alert_total ?? '-'} icon={<PendingActionsRoundedIcon />} color="#d9822b" loading={loading} />
+        <StatCard title="待随访任务" value={overview?.todo_followup_total ?? '-'} icon={<LocalHospitalRoundedIcon />} color="#0f9d8f" loading={loading} />
+        <StatCard title="今日已完成随访" value={overview?.completed_followup_today ?? '-'} icon={<CheckCircleRoundedIcon />} color="#1f9d63" loading={loading} />
+        <StatCard title="今日评估数" value={overview?.assessment_total_today ?? '-'} icon={<InsightsRoundedIcon />} color="#13c2c2" loading={loading} />
+      </Box>
 
-      <Row gutter={[16, 16]} style={{ marginTop: 16 }}>
-        <Col xs={24} lg={16}>
-          <Card
-            title="趋势数据"
-            extra={
-              <Select
-                value={trendRange}
-                onChange={setTrendRange}
-                options={[
-                  { label: '近7天', value: '7d' },
-                  { label: '近30天', value: '30d' },
-                  { label: '近90天', value: '90d' },
-                ]}
-                style={{ width: 100 }}
-              />
-            }
-          >
-            {trends && <ReactECharts option={chartOption} style={{ height: 350 }} />}
-          </Card>
-        </Col>
-        <Col xs={24} lg={8}>
-          <Card title="近期待办" style={{ height: '100%' }}>
-            <List
-              loading={loading}
-              dataSource={todos}
-              renderItem={(item) => (
-                <List.Item>
-                  <List.Item.Meta
-                    title={
-                      <span>
-                        <Tag color="blue">{item.type}</Tag>
-                        {item.title}
-                      </span>
+      <Box
+        sx={{
+          display: 'grid',
+          gap: 2,
+          gridTemplateColumns: { xs: '1fr', lg: 'minmax(0, 2fr) minmax(320px, 1fr)' },
+        }}
+      >
+        <Card sx={{ height: '100%' }}>
+          <CardContent>
+            <Stack
+              direction={{ xs: 'column', sm: 'row' }}
+              justifyContent="space-between"
+              spacing={2}
+              sx={{ mb: 2 }}
+            >
+              <Box>
+                <Typography variant="h6">趋势数据</Typography>
+                <Typography variant="body2" color="text.secondary">
+                  近7天、30天或90天的变化趋势
+                </Typography>
+              </Box>
+              <FormControl size="small" sx={{ minWidth: 140 }}>
+                <InputLabel>时间范围</InputLabel>
+                <Select
+                  label="时间范围"
+                  value={trendRange}
+                  onChange={(event) => setTrendRange(event.target.value as string)}
+                >
+                  <MenuItem value="7d">近7天</MenuItem>
+                  <MenuItem value="30d">近30天</MenuItem>
+                  <MenuItem value="90d">近90天</MenuItem>
+                </Select>
+              </FormControl>
+            </Stack>
+            {trends ? (
+              <ReactECharts option={chartOption} style={{ height: 350 }} />
+            ) : (
+              <Typography color="text.secondary" sx={{ py: 6, textAlign: 'center' }}>
+                暂无趋势数据
+              </Typography>
+            )}
+          </CardContent>
+        </Card>
+
+        <Card sx={{ height: '100%' }}>
+          <CardContent>
+            <Typography variant="h6" sx={{ mb: 1 }}>
+              近期待办
+            </Typography>
+            <List disablePadding>
+              {todos.map((item) => (
+                <ListItem
+                  key={item.id}
+                  divider
+                  disableGutters
+                  sx={{ py: 1.25, alignItems: 'flex-start' }}
+                >
+                  <ListItemText
+                    primary={
+                      <Stack direction="row" spacing={1} flexWrap="wrap" sx={{ mb: 0.75 }}>
+                        <Chip label={item.type} size="small" variant="outlined" />
+                        <Chip
+                          label={item.priority}
+                          size="small"
+                          color={todoPriorityColor[item.priority] || 'default'}
+                          variant="outlined"
+                        />
+                      </Stack>
                     }
-                    description={item.description}
+                    secondary={
+                      <>
+                        <Typography component="span" variant="body2" color="text.primary">
+                          {item.title}
+                        </Typography>
+                        <Typography component="span" variant="body2" display="block">
+                          {item.description}
+                        </Typography>
+                      </>
+                    }
                   />
-                </List.Item>
+                </ListItem>
+              ))}
+              {!loading && todos.length === 0 && (
+                <Typography color="text.secondary" sx={{ py: 4, textAlign: 'center' }}>
+                  暂无待办事项
+                </Typography>
               )}
-              locale={{ emptyText: '暂无待办事项' }}
-            />
-          </Card>
-        </Col>
-      </Row>
-    </div>
+            </List>
+          </CardContent>
+        </Card>
+      </Box>
+    </Box>
   );
 };
 

--- a/frontend/src/pages/doctors/DoctorPage.tsx
+++ b/frontend/src/pages/doctors/DoctorPage.tsx
@@ -1,8 +1,9 @@
-import React, { useState, useCallback } from 'react';
-import { Button, Tag, Space, Popconfirm, message } from 'antd';
-import { PlusOutlined, EditOutlined, DeleteOutlined } from '@ant-design/icons';
-import type { ColumnsType } from 'antd/es/table';
-import AppTable from '../../components/AppTable';
+import React, { useCallback, useState } from 'react';
+import { Button, Chip, Stack } from '@mui/material';
+import AddRoundedIcon from '@mui/icons-material/AddRounded';
+import EditRoundedIcon from '@mui/icons-material/EditRounded';
+import DeleteRoundedIcon from '@mui/icons-material/DeleteRounded';
+import AppTable, { type AppTableColumn } from '../../components/AppTable';
 import AppForm, { type FormFieldConfig } from '../../components/AppForm';
 import PermissionGuard from '../../components/PermissionGuard';
 import { useTable } from '../../hooks/useTable';
@@ -10,6 +11,7 @@ import { getUsers, createUser, updateUser, deleteUser } from '../../api/users';
 import { formatDateTime } from '../../utils/formatter';
 import type { User } from '../../types/user';
 import type { PaginationParams } from '../../types/common';
+import { message } from '../../utils/message';
 
 const createFields: FormFieldConfig[] = [
   { name: 'username', label: '用户名', required: true },
@@ -37,6 +39,7 @@ const editFields: FormFieldConfig[] = [
 const DoctorPage: React.FC = () => {
   const [formVisible, setFormVisible] = useState(false);
   const [editingUser, setEditingUser] = useState<User | null>(null);
+  const [submitLoading, setSubmitLoading] = useState(false);
 
   const fetchFn = useCallback(
     (params: PaginationParams & { page: number; page_size: number }) =>
@@ -58,6 +61,10 @@ const DoctorPage: React.FC = () => {
   };
 
   const handleDelete = async (id: number) => {
+    if (!window.confirm('确定删除该医生？')) {
+      return;
+    }
+
     try {
       await deleteUser(id);
       message.success('删除成功');
@@ -67,7 +74,7 @@ const DoctorPage: React.FC = () => {
     }
   };
 
-  const columns: ColumnsType<User> = [
+  const columns: AppTableColumn<User>[] = [
     { title: '用户名', dataIndex: 'username', width: 120 },
     { title: '姓名', dataIndex: 'real_name', width: 100 },
     { title: '手机号', dataIndex: 'phone', width: 130 },
@@ -77,9 +84,12 @@ const DoctorPage: React.FC = () => {
       dataIndex: 'status',
       width: 80,
       render: (status: string) => (
-        <Tag color={status === 'active' ? 'green' : 'red'}>
-          {status === 'active' ? '正常' : '禁用'}
-        </Tag>
+        <Chip
+          size="small"
+          color={status === 'active' ? 'success' : 'error'}
+          variant="outlined"
+          label={status === 'active' ? '正常' : '禁用'}
+        />
       ),
     },
     { title: '创建时间', dataIndex: 'created_at', render: formatDateTime, width: 170 },
@@ -89,23 +99,27 @@ const DoctorPage: React.FC = () => {
       width: 160,
       fixed: 'right',
       render: (_, record) => (
-        <Space>
+        <Stack direction="row" spacing={0.5}>
           <PermissionGuard permission="user:manage">
             <Button
-              type="link"
               size="small"
-              icon={<EditOutlined />}
+              variant="text"
+              startIcon={<EditRoundedIcon fontSize="small" />}
               onClick={() => handleEdit(record)}
             >
               编辑
             </Button>
-            <Popconfirm title="确定删除该医生？" onConfirm={() => handleDelete(record.id)}>
-              <Button type="link" size="small" danger icon={<DeleteOutlined />}>
-                删除
-              </Button>
-            </Popconfirm>
+            <Button
+              size="small"
+              variant="text"
+              color="error"
+              startIcon={<DeleteRoundedIcon fontSize="small" />}
+              onClick={() => handleDelete(record.id)}
+            >
+              删除
+            </Button>
           </PermissionGuard>
-        </Space>
+        </Stack>
       ),
     },
   ];
@@ -122,7 +136,7 @@ const DoctorPage: React.FC = () => {
         searchPlaceholder="搜索用户名/姓名/手机号"
         toolbar={
           <PermissionGuard permission="user:manage">
-            <Button type="primary" icon={<PlusOutlined />} onClick={handleCreate}>
+            <Button variant="contained" startIcon={<AddRoundedIcon />} onClick={handleCreate}>
               新增医生
             </Button>
           </PermissionGuard>
@@ -134,15 +148,21 @@ const DoctorPage: React.FC = () => {
         visible={formVisible}
         fields={editingUser ? editFields : createFields}
         initialValues={editingUser || undefined}
+        confirmLoading={submitLoading}
         onSubmit={async (values) => {
-          if (editingUser) {
-            await updateUser(editingUser.id, values as Parameters<typeof updateUser>[1]);
-          } else {
-            await createUser({ ...values, role_ids: [2] } as Parameters<typeof createUser>[0]);
+          setSubmitLoading(true);
+          try {
+            if (editingUser) {
+              await updateUser(editingUser.id, values as Parameters<typeof updateUser>[1]);
+            } else {
+              await createUser({ ...values, role_ids: [2] } as Parameters<typeof createUser>[0]);
+            }
+            message.success(editingUser ? '更新成功' : '创建成功');
+            setFormVisible(false);
+            refresh();
+          } finally {
+            setSubmitLoading(false);
           }
-          message.success(editingUser ? '更新成功' : '创建成功');
-          setFormVisible(false);
-          refresh();
         }}
         onCancel={() => setFormVisible(false)}
       />

--- a/frontend/src/pages/doctors/DoctorPage.tsx
+++ b/frontend/src/pages/doctors/DoctorPage.tsx
@@ -1,8 +1,9 @@
-import React, { useState, useCallback } from 'react';
-import { Button, Tag, Space, Popconfirm, message } from 'antd';
-import { PlusOutlined, EditOutlined, DeleteOutlined } from '@ant-design/icons';
-import type { ColumnsType } from 'antd/es/table';
-import AppTable from '../../components/AppTable';
+import React, { useCallback, useState } from 'react';
+import { Button, Chip, Stack } from '@mui/material';
+import AddRoundedIcon from '@mui/icons-material/AddRounded';
+import EditRoundedIcon from '@mui/icons-material/EditRounded';
+import DeleteRoundedIcon from '@mui/icons-material/DeleteRounded';
+import AppTable, { type AppTableColumn } from '../../components/AppTable';
 import AppForm, { type FormFieldConfig } from '../../components/AppForm';
 import PermissionGuard from '../../components/PermissionGuard';
 import { useTable } from '../../hooks/useTable';
@@ -10,6 +11,7 @@ import { getUsers, createUser, updateUser, deleteUser } from '../../api/users';
 import { formatDateTime } from '../../utils/formatter';
 import type { User } from '../../types/user';
 import type { PaginationParams } from '../../types/common';
+import { message } from '../../utils/message';
 
 const createFields: FormFieldConfig[] = [
   { name: 'username', label: '用户名', required: true },
@@ -37,6 +39,7 @@ const editFields: FormFieldConfig[] = [
 const DoctorPage: React.FC = () => {
   const [formVisible, setFormVisible] = useState(false);
   const [editingUser, setEditingUser] = useState<User | null>(null);
+  const [submitLoading, setSubmitLoading] = useState(false);
 
   const fetchFn = useCallback(
     (params: PaginationParams & { page: number; page_size: number }) =>
@@ -58,6 +61,10 @@ const DoctorPage: React.FC = () => {
   };
 
   const handleDelete = async (id: number) => {
+    if (!window.confirm('确定删除该医生？')) {
+      return;
+    }
+
     try {
       await deleteUser(id);
       message.success('删除成功');
@@ -67,7 +74,7 @@ const DoctorPage: React.FC = () => {
     }
   };
 
-  const columns: ColumnsType<User> = [
+  const columns: AppTableColumn<User>[] = [
     { title: '用户名', dataIndex: 'username', width: 120 },
     { title: '姓名', dataIndex: 'real_name', width: 100 },
     { title: '手机号', dataIndex: 'phone', width: 130 },
@@ -76,36 +83,51 @@ const DoctorPage: React.FC = () => {
       title: '状态',
       dataIndex: 'status',
       width: 80,
-      render: (status: string) => (
-        <Tag color={status === 'active' ? 'green' : 'red'}>
-          {status === 'active' ? '正常' : '禁用'}
-        </Tag>
-      ),
+      render: (value) => {
+        const status = String(value);
+        return (
+          <Chip
+            size="small"
+            color={status === 'active' ? 'success' : 'error'}
+            variant="outlined"
+            label={status === 'active' ? '正常' : '禁用'}
+          />
+        );
+      },
     },
-    { title: '创建时间', dataIndex: 'created_at', render: formatDateTime, width: 170 },
+    {
+      title: '创建时间',
+      dataIndex: 'created_at',
+      render: (value) => formatDateTime(value as string | null | undefined),
+      width: 170,
+    },
     {
       title: '操作',
       key: 'actions',
       width: 160,
       fixed: 'right',
       render: (_, record) => (
-        <Space>
+        <Stack direction="row" spacing={0.5}>
           <PermissionGuard permission="user:manage">
             <Button
-              type="link"
               size="small"
-              icon={<EditOutlined />}
+              variant="text"
+              startIcon={<EditRoundedIcon fontSize="small" />}
               onClick={() => handleEdit(record)}
             >
               编辑
             </Button>
-            <Popconfirm title="确定删除该医生？" onConfirm={() => handleDelete(record.id)}>
-              <Button type="link" size="small" danger icon={<DeleteOutlined />}>
-                删除
-              </Button>
-            </Popconfirm>
+            <Button
+              size="small"
+              variant="text"
+              color="error"
+              startIcon={<DeleteRoundedIcon fontSize="small" />}
+              onClick={() => handleDelete(record.id)}
+            >
+              删除
+            </Button>
           </PermissionGuard>
-        </Space>
+        </Stack>
       ),
     },
   ];
@@ -122,7 +144,7 @@ const DoctorPage: React.FC = () => {
         searchPlaceholder="搜索用户名/姓名/手机号"
         toolbar={
           <PermissionGuard permission="user:manage">
-            <Button type="primary" icon={<PlusOutlined />} onClick={handleCreate}>
+            <Button variant="contained" startIcon={<AddRoundedIcon />} onClick={handleCreate}>
               新增医生
             </Button>
           </PermissionGuard>
@@ -134,15 +156,21 @@ const DoctorPage: React.FC = () => {
         visible={formVisible}
         fields={editingUser ? editFields : createFields}
         initialValues={editingUser || undefined}
+        confirmLoading={submitLoading}
         onSubmit={async (values) => {
-          if (editingUser) {
-            await updateUser(editingUser.id, values as Parameters<typeof updateUser>[1]);
-          } else {
-            await createUser({ ...values, role_ids: [2] } as Parameters<typeof createUser>[0]);
+          setSubmitLoading(true);
+          try {
+            if (editingUser) {
+              await updateUser(editingUser.id, values as Parameters<typeof updateUser>[1]);
+            } else {
+              await createUser({ ...values, role_ids: [2] } as Parameters<typeof createUser>[0]);
+            }
+            message.success(editingUser ? '更新成功' : '创建成功');
+            setFormVisible(false);
+            refresh();
+          } finally {
+            setSubmitLoading(false);
           }
-          message.success(editingUser ? '更新成功' : '创建成功');
-          setFormVisible(false);
-          refresh();
         }}
         onCancel={() => setFormVisible(false)}
       />

--- a/frontend/src/pages/elder-portal/ElderHomePage.tsx
+++ b/frontend/src/pages/elder-portal/ElderHomePage.tsx
@@ -1,10 +1,19 @@
-import React, { useEffect, useState } from 'react';
-import { Card, Descriptions, Spin, Tag, Table, Typography, Alert } from 'antd';
-import type { ColumnsType } from 'antd/es/table';
+import React, { useEffect, useMemo, useState } from 'react';
+import {
+  Alert,
+  Box,
+  Card,
+  CardContent,
+  Chip,
+  CircularProgress,
+  Stack,
+  Typography,
+} from '@mui/material';
+import FavoriteRoundedIcon from '@mui/icons-material/FavoriteRounded';
 import { useAuthStore } from '../../store/auth';
 import { getElderSelf, getElderHealthRecords } from '../../api/elderPortal';
-
-const { Title } = Typography;
+import AppTable, { type AppTableColumn } from '../../components/AppTable';
+import { formatDate, formatDateTime } from '../../utils/formatter';
 
 interface ElderProfile {
   id: number;
@@ -24,6 +33,19 @@ interface HealthRecord {
   record_type: string;
   summary: string;
   created_at: string;
+}
+
+function FieldItem({ label, value }: { label: string; value: React.ReactNode }) {
+  return (
+    <Box sx={{ p: 2, borderRadius: 2, bgcolor: 'background.default' }}>
+      <Typography variant="body2" color="text.secondary">
+        {label}
+      </Typography>
+      <Typography variant="subtitle1" sx={{ mt: 0.5, fontWeight: 600 }}>
+        {value}
+      </Typography>
+    </Box>
+  );
 }
 
 const ElderHomePage: React.FC = () => {
@@ -46,7 +68,7 @@ const ElderHomePage: React.FC = () => {
         setProfileLoading(false);
       }
     };
-    fetchProfile();
+    void fetchProfile();
   }, []);
 
   useEffect(() => {
@@ -59,12 +81,12 @@ const ElderHomePage: React.FC = () => {
         const res = await getElderHealthRecords(elderId, { page: 1, page_size: 5 });
         setHealthRecords(res.data?.items || []);
       } catch {
-        // Silently handle — profile section is more important
+        // Profile section is more important; keep the page usable.
       } finally {
         setRecordsLoading(false);
       }
     };
-    fetchRecords();
+    void fetchRecords();
   }, [user?.elder_id]);
 
   const genderMap: Record<string, string> = {
@@ -74,18 +96,19 @@ const ElderHomePage: React.FC = () => {
     F: '女',
   };
 
-  const columns: ColumnsType<HealthRecord> = [
+  const columns = useMemo<AppTableColumn<HealthRecord>[]>(() => [
     {
       title: '记录日期',
       dataIndex: 'record_date',
       key: 'record_date',
       width: 120,
+      render: (value) => formatDate(value as string | undefined),
     },
     {
       title: '类型',
       dataIndex: 'record_type',
       key: 'record_type',
-      width: 100,
+      width: 120,
     },
     {
       title: '摘要',
@@ -98,65 +121,93 @@ const ElderHomePage: React.FC = () => {
       dataIndex: 'created_at',
       key: 'created_at',
       width: 180,
+      render: (value) => formatDateTime(value as string | undefined),
     },
-  ];
+  ], []);
 
   if (profileLoading) {
     return (
-      <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '50vh' }}>
-        <Spin size="large" />
-      </div>
+      <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: '50vh' }}>
+        <CircularProgress size={44} />
+      </Box>
     );
   }
 
   if (error) {
-    return <Alert type="error" message="加载失败" description={error} showIcon />;
+    return (
+      <Alert severity="error" variant="filled" sx={{ alignItems: 'center' }}>
+        {error}
+      </Alert>
+    );
   }
 
   return (
-    <div>
-      <Card style={{ marginBottom: 16 }}>
-        <Title level={4} style={{ marginBottom: 16 }}>
-          {profile?.name ? `${profile.name}，您好！` : '您好！'}
-        </Title>
-        <Descriptions column={{ xs: 1, sm: 2 }} bordered>
-          <Descriptions.Item label="姓名">{profile?.name || '-'}</Descriptions.Item>
-          <Descriptions.Item label="性别">
-            {profile?.gender ? (genderMap[profile.gender] || profile.gender) : '-'}
-          </Descriptions.Item>
-          <Descriptions.Item label="出生日期">{profile?.birth_date || '-'}</Descriptions.Item>
-          <Descriptions.Item label="联系电话">{profile?.phone || '-'}</Descriptions.Item>
-          <Descriptions.Item label="住址" span={2}>{profile?.address || '-'}</Descriptions.Item>
-          <Descriptions.Item label="紧急联系人">
-            {profile?.emergency_contact_name || '-'}
-          </Descriptions.Item>
-          <Descriptions.Item label="紧急联系电话">
-            {profile?.emergency_contact_phone || '-'}
-          </Descriptions.Item>
-          {profile?.tags && profile.tags.length > 0 && (
-            <Descriptions.Item label="标签" span={2}>
-              {profile.tags.map((tag) => (
-                <Tag color="blue" key={tag}>
-                  {tag}
-                </Tag>
-              ))}
-            </Descriptions.Item>
-          )}
-        </Descriptions>
+    <Stack spacing={3}>
+      <Card>
+        <CardContent>
+          <Stack spacing={2.5}>
+            <Box>
+              <Stack direction="row" spacing={1.5} alignItems="center">
+                <FavoriteRoundedIcon color="error" />
+                <Typography variant="h6" sx={{ fontWeight: 700 }}>
+                  {profile?.name ? `${profile.name}，您好！` : '您好！'}
+                </Typography>
+              </Stack>
+              <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
+                以下是您的基础信息与最近健康记录。
+              </Typography>
+            </Box>
+
+            <Box
+              sx={{
+                display: 'grid',
+                gridTemplateColumns: { xs: '1fr', sm: 'repeat(2, minmax(0, 1fr))' },
+                gap: 2,
+              }}
+            >
+              <FieldItem label="姓名" value={profile?.name || '-'} />
+              <FieldItem
+                label="性别"
+                value={profile?.gender ? (genderMap[profile.gender] || profile.gender) : '-'}
+              />
+              <FieldItem label="出生日期" value={formatDate(profile?.birth_date)} />
+              <FieldItem label="联系电话" value={profile?.phone || '-'} />
+              <FieldItem label="住址" value={profile?.address || '-'} />
+              <FieldItem label="紧急联系人" value={profile?.emergency_contact_name || '-'} />
+              <FieldItem label="紧急联系电话" value={profile?.emergency_contact_phone || '-'} />
+              <FieldItem
+                label="标签"
+                value={
+                  profile?.tags && profile.tags.length > 0 ? (
+                    <Stack direction="row" spacing={1} useFlexGap flexWrap="wrap">
+                      {profile.tags.map((tag) => (
+                        <Chip key={tag} color="primary" variant="outlined" label={tag} />
+                      ))}
+                    </Stack>
+                  ) : (
+                    '-'
+                  )
+                }
+              />
+            </Box>
+          </Stack>
+        </CardContent>
       </Card>
 
-      <Card title="近期健康记录">
-        <Table<HealthRecord>
+      <Box>
+        <Typography variant="h6" sx={{ fontWeight: 700, mb: 1.5 }}>
+          近期健康记录
+        </Typography>
+        <AppTable<HealthRecord>
           columns={columns}
           dataSource={healthRecords}
           loading={recordsLoading}
           rowKey="id"
           pagination={false}
-          locale={{ emptyText: '暂无健康记录' }}
-          scroll={{ x: 'max-content' }}
+          emptyText="暂无健康记录"
         />
-      </Card>
-    </div>
+      </Box>
+    </Stack>
   );
 };
 

--- a/frontend/src/pages/elder-portal/ElderInvitePage.tsx
+++ b/frontend/src/pages/elder-portal/ElderInvitePage.tsx
@@ -1,24 +1,24 @@
-import React, { useEffect, useState, useCallback } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import {
-  Card,
-  Button,
-  Typography,
-  Table,
-  Space,
-  Spin,
   Alert,
-  Empty,
-  Modal,
-  message,
-  Tag,
-} from 'antd';
-import {
-  CopyOutlined,
-  PlusOutlined,
-  DeleteOutlined,
-  ExclamationCircleOutlined,
-} from '@ant-design/icons';
-import type { ColumnsType } from 'antd/es/table';
+  Box,
+  Button,
+  Card,
+  CardContent,
+  Chip,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+  Stack,
+  Typography,
+} from '@mui/material';
+import ContentCopyRoundedIcon from '@mui/icons-material/ContentCopyRounded';
+import AddRoundedIcon from '@mui/icons-material/AddRounded';
+import DeleteOutlineRoundedIcon from '@mui/icons-material/DeleteOutlineRounded';
+import WarningAmberRoundedIcon from '@mui/icons-material/WarningAmberRounded';
 import { useAuthStore } from '../../store/auth';
 import {
   getInviteCode,
@@ -26,8 +26,9 @@ import {
   revokeInviteCode,
   getElderFamily,
 } from '../../api/elderPortal';
-
-const { Title, Text, Paragraph } = Typography;
+import AppTable, { type AppTableColumn } from '../../components/AppTable';
+import { formatDateTime } from '../../utils/formatter';
+import { message } from '../../utils/message';
 
 interface InviteCode {
   code: string;
@@ -55,6 +56,7 @@ const ElderInvitePage: React.FC = () => {
   const [familyLoading, setFamilyLoading] = useState(true);
   const [actionLoading, setActionLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [revokeOpen, setRevokeOpen] = useState(false);
 
   const fetchInviteCode = useCallback(async () => {
     if (!elderId) return;
@@ -82,8 +84,8 @@ const ElderInvitePage: React.FC = () => {
   }, []);
 
   useEffect(() => {
-    fetchInviteCode();
-    fetchFamily();
+    void fetchInviteCode();
+    void fetchFamily();
   }, [fetchInviteCode, fetchFamily]);
 
   const handleGenerate = async () => {
@@ -102,39 +104,38 @@ const ElderInvitePage: React.FC = () => {
 
   const handleRevoke = () => {
     if (!elderId) return;
-    Modal.confirm({
-      title: '确认撤销',
-      icon: <ExclamationCircleOutlined />,
-      content: '撤销后，当前邀请码将立即失效，已绑定的家属不受影响。',
-      okText: '确认撤销',
-      cancelText: '取消',
-      okButtonProps: { danger: true },
-      onOk: async () => {
-        setActionLoading(true);
-        try {
-          await revokeInviteCode(elderId);
-          message.success('邀请码已撤销');
-          setInviteCode(null);
-        } catch (err) {
-          message.error(err instanceof Error ? err.message : '撤销邀请码失败');
-        } finally {
-          setActionLoading(false);
-        }
-      },
-    });
+    setRevokeOpen(true);
+  };
+
+  const handleConfirmRevoke = async () => {
+    if (!elderId) return;
+    setActionLoading(true);
+    try {
+      await revokeInviteCode(elderId);
+      message.success('邀请码已撤销');
+      setInviteCode(null);
+      setRevokeOpen(false);
+    } catch (err) {
+      message.error(err instanceof Error ? err.message : '撤销邀请码失败');
+    } finally {
+      setActionLoading(false);
+    }
   };
 
   const handleCopyLink = () => {
     if (!inviteCode) return;
     const link = `${window.location.origin}/register/family?code=${inviteCode.code}`;
-    navigator.clipboard.writeText(link).then(() => {
-      message.success('邀请链接已复制到剪贴板');
-    }).catch(() => {
-      message.error('复制失败，请手动复制');
-    });
+    navigator.clipboard
+      .writeText(link)
+      .then(() => {
+        message.success('邀请链接已复制到剪贴板');
+      })
+      .catch(() => {
+        message.error('复制失败，请手动复制');
+      });
   };
 
-  const familyColumns: ColumnsType<FamilyMember> = [
+  const familyColumns = useMemo<AppTableColumn<FamilyMember>[]>(() => [
     {
       title: '姓名',
       dataIndex: 'real_name',
@@ -150,98 +151,143 @@ const ElderInvitePage: React.FC = () => {
       dataIndex: 'created_at',
       key: 'created_at',
       width: 180,
+      render: (value) => formatDateTime(value as string | undefined),
     },
-  ];
+  ], []);
 
   if (!elderId) {
-    return <Alert type="warning" message="账户异常" description="未找到关联的老人信息，请联系管理员。" showIcon />;
+    return (
+      <Alert severity="warning" variant="filled" icon={<WarningAmberRoundedIcon />}>
+        未找到关联的老人信息，请联系管理员。
+      </Alert>
+    );
   }
 
   return (
-    <div>
-      <Card style={{ marginBottom: 16 }}>
-        <Title level={4} style={{ marginTop: 0 }}>邀请家属</Title>
-        <Paragraph type="secondary">
-          生成邀请码分享给家属，家属可通过邀请码注册并绑定账号。每位老人最多绑定 {MAX_FAMILY_MEMBERS} 位家属。
-        </Paragraph>
+    <Stack spacing={3}>
+      <Card>
+        <CardContent>
+          <Stack spacing={2.5}>
+            <Box>
+              <Typography variant="h6" sx={{ fontWeight: 700 }}>
+                邀请家属
+              </Typography>
+              <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
+                生成邀请码分享给家属，家属可通过邀请码注册并绑定账号。每位老人最多绑定 {MAX_FAMILY_MEMBERS} 位家属。
+              </Typography>
+            </Box>
 
-        {codeLoading ? (
-          <div style={{ textAlign: 'center', padding: 24 }}>
-            <Spin />
-          </div>
-        ) : inviteCode ? (
-          <Card
-            type="inner"
-            style={{ marginBottom: 16, background: '#fafafa' }}
-          >
-            <Space direction="vertical" size="middle" style={{ width: '100%' }}>
-              <div>
-                <Text type="secondary">当前邀请码</Text>
-                <div style={{ marginTop: 8 }}>
-                  <Text
-                    copyable
-                    style={{ fontSize: 28, fontWeight: 700, letterSpacing: 2 }}
-                  >
-                    {inviteCode.code}
-                  </Text>
-                </div>
-              </div>
-              <Space split={<span style={{ color: '#d9d9d9' }}>|</span>}>
-                <Text type="secondary">
-                  过期时间：{inviteCode.expires_at}
-                </Text>
-                <Tag color={inviteCode.used_count >= inviteCode.max_uses ? 'red' : 'blue'}>
-                  已使用 {inviteCode.used_count}/{inviteCode.max_uses}
-                </Tag>
-              </Space>
-              <Space>
+            {codeLoading ? (
+              <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+                <CircularProgress />
+              </Box>
+            ) : inviteCode ? (
+              <Box
+                sx={{
+                  p: { xs: 2.5, sm: 3 },
+                  borderRadius: 3,
+                  border: '1px solid',
+                  borderColor: 'divider',
+                  bgcolor: 'background.default',
+                }}
+              >
+                <Stack spacing={2}>
+                  <Box>
+                    <Typography variant="body2" color="text.secondary">
+                      当前邀请码
+                    </Typography>
+                    <Typography
+                      variant="h4"
+                      sx={{ mt: 1, fontWeight: 800, letterSpacing: 3, wordBreak: 'break-all' }}
+                    >
+                      {inviteCode.code}
+                    </Typography>
+                  </Box>
+
+                  <Stack direction="row" spacing={1} useFlexGap flexWrap="wrap">
+                    <Chip variant="outlined" label={`过期时间：${inviteCode.expires_at}`} />
+                    <Chip
+                      color={inviteCode.used_count >= inviteCode.max_uses ? 'error' : 'primary'}
+                      label={`已使用 ${inviteCode.used_count}/${inviteCode.max_uses}`}
+                    />
+                  </Stack>
+
+                  <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1.5}>
+                    <Button
+                      variant="outlined"
+                      startIcon={<ContentCopyRoundedIcon />}
+                      onClick={handleCopyLink}
+                    >
+                      复制邀请链接
+                    </Button>
+                    <Button
+                      color="error"
+                      variant="contained"
+                      startIcon={<DeleteOutlineRoundedIcon />}
+                      disabled={actionLoading}
+                      onClick={handleRevoke}
+                    >
+                      撤销邀请码
+                    </Button>
+                  </Stack>
+                </Stack>
+              </Box>
+            ) : (
+              <Box sx={{ textAlign: 'center', py: 4 }}>
+                <Typography variant="body2" color="text.secondary">
+                  暂无有效邀请码
+                </Typography>
                 <Button
-                  icon={<CopyOutlined />}
-                  onClick={handleCopyLink}
+                  sx={{ mt: 2 }}
+                  variant="contained"
+                  startIcon={<AddRoundedIcon />}
+                  disabled={actionLoading}
+                  onClick={handleGenerate}
                 >
-                  复制邀请链接
+                  生成邀请码
                 </Button>
-                <Button
-                  danger
-                  icon={<DeleteOutlined />}
-                  loading={actionLoading}
-                  onClick={handleRevoke}
-                >
-                  撤销邀请码
-                </Button>
-              </Space>
-            </Space>
-          </Card>
-        ) : (
-          <div style={{ textAlign: 'center', padding: 24 }}>
-            <Empty description="暂无有效邀请码" style={{ marginBottom: 16 }} />
-            <Button
-              type="primary"
-              icon={<PlusOutlined />}
-              loading={actionLoading}
-              onClick={handleGenerate}
-            >
-              生成邀请码
-            </Button>
-          </div>
-        )}
+              </Box>
+            )}
+          </Stack>
+        </CardContent>
       </Card>
 
-      <Card title="已绑定家属">
-        <Table<FamilyMember>
+      <Box>
+        <Typography variant="h6" sx={{ fontWeight: 700, mb: 1.5 }}>
+          已绑定家属
+        </Typography>
+        <AppTable<FamilyMember>
           columns={familyColumns}
           dataSource={familyMembers}
           loading={familyLoading}
           rowKey="id"
           pagination={false}
-          locale={{ emptyText: '暂无绑定家属' }}
-          scroll={{ x: 'max-content' }}
+          emptyText="暂无绑定家属"
         />
         {error && (
-          <Alert type="error" message={error} style={{ marginTop: 16 }} showIcon />
+          <Alert severity="error" variant="outlined" sx={{ mt: 2 }}>
+            {error}
+          </Alert>
         )}
-      </Card>
-    </div>
+      </Box>
+
+      <Dialog open={revokeOpen} onClose={() => setRevokeOpen(false)} maxWidth="xs" fullWidth>
+        <DialogTitle>确认撤销</DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            撤销后，当前邀请码将立即失效，已绑定的家属不受影响。
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions sx={{ px: 3, pb: 2.5 }}>
+          <Button onClick={() => setRevokeOpen(false)} color="inherit">
+            取消
+          </Button>
+          <Button onClick={handleConfirmRevoke} color="error" variant="contained" disabled={actionLoading}>
+            确认撤销
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </Stack>
   );
 };
 

--- a/frontend/src/pages/elders/ElderArchiveListPage.tsx
+++ b/frontend/src/pages/elders/ElderArchiveListPage.tsx
@@ -1,69 +1,145 @@
-import React, { useCallback } from 'react';
-import { Card, Row, Col, Tag, Input, Spin, Empty } from 'antd';
+import React, { useCallback, useMemo, useState } from 'react';
+import {
+  Box,
+  Card,
+  CardActionArea,
+  Chip,
+  CircularProgress,
+  InputAdornment,
+  Stack,
+  TextField,
+  Typography,
+} from '@mui/material';
+import SearchRoundedIcon from '@mui/icons-material/SearchRounded';
 import { useNavigate } from 'react-router-dom';
 import { useTable } from '../../hooks/useTable';
 import { getElders } from '../../api/elders';
 import { formatGender } from '../../utils/formatter';
 import type { Elder, ElderListQuery } from '../../types/elder';
 
-const { Search } = Input;
-
 const ElderArchiveListPage: React.FC = () => {
   const navigate = useNavigate();
+  const [keyword, setKeyword] = useState('');
 
   const fetchFn = useCallback(
     (params: ElderListQuery & { page: number; page_size: number }) => getElders(params),
     [],
   );
 
-  const { data, loading, handleSearch } = useTable<Elder, ElderListQuery>(fetchFn);
+  const { data, loading, setQuery } = useTable<Elder, ElderListQuery>(fetchFn);
+
+  const handleSearch = useCallback(() => {
+    setQuery((prev) => ({ ...prev, keyword: keyword.trim() } as ElderListQuery));
+  }, [keyword, setQuery]);
+
+  const items = useMemo(
+    () =>
+      data.map((elder) => (
+        <Box key={elder.id} sx={{ width: { xs: '100%', sm: '50%', md: '33.333%', lg: '25%' } }}>
+          <Card
+            variant="outlined"
+            sx={{
+              height: '100%',
+              borderRadius: 4,
+              overflow: 'hidden',
+            }}
+          >
+            <CardActionArea
+              onClick={() => navigate(`/elders/${elder.id}/archive`)}
+              sx={{ height: '100%', alignItems: 'stretch' }}
+            >
+              <Box sx={{ p: 2.5, height: '100%' }}>
+                <Stack spacing={1.5} sx={{ height: '100%' }}>
+                  <Box>
+                    <Typography variant="h6" sx={{ fontWeight: 700, mb: 0.5 }}>
+                      {elder.name}
+                    </Typography>
+                    <Typography variant="body2" color="text.secondary">
+                      {formatGender(elder.gender)} · {elder.phone || '-'}
+                    </Typography>
+                  </Box>
+                  <Box sx={{ flex: 1 }}>
+                    <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 0.75 }}>
+                      标签
+                    </Typography>
+                    <Stack direction="row" spacing={1} useFlexGap flexWrap="wrap">
+                      {elder.tags?.length ? (
+                        elder.tags.map((tag) => (
+                          <Chip key={tag} label={tag} color="primary" variant="outlined" size="small" />
+                        ))
+                      ) : (
+                        <Typography variant="body2" color="text.secondary">
+                          暂无标签
+                        </Typography>
+                      )}
+                    </Stack>
+                  </Box>
+                  <Typography variant="body2" color="text.secondary">
+                    点击查看健康档案
+                  </Typography>
+                </Stack>
+              </Box>
+            </CardActionArea>
+          </Card>
+        </Box>
+      )),
+    [data, navigate],
+  );
 
   return (
-    <div>
-      <div style={{ marginBottom: 16, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-        <h2 style={{ margin: 0 }}>老人健康档案</h2>
-        <Search
+    <Stack spacing={2.5}>
+      <Stack
+        direction={{ xs: 'column', sm: 'row' }}
+        justifyContent="space-between"
+        alignItems={{ xs: 'stretch', sm: 'center' }}
+        spacing={2}
+      >
+        <Box>
+          <Typography variant="h5" sx={{ fontWeight: 700, mb: 0.5 }}>
+            老人健康档案
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            查看并进入单个老人的健康档案详情
+          </Typography>
+        </Box>
+
+        <TextField
+          value={keyword}
+          onChange={(event) => setKeyword(event.target.value)}
+          onKeyDown={(event) => {
+            if (event.key === 'Enter') {
+              handleSearch();
+            }
+          }}
           placeholder="搜索姓名/手机号/身份证"
-          allowClear
-          onSearch={handleSearch}
-          style={{ width: 300 }}
+          size="small"
+          sx={{ width: { xs: '100%', sm: 340 } }}
+          InputProps={{
+            endAdornment: (
+              <InputAdornment position="end">
+                <SearchRoundedIcon fontSize="small" />
+              </InputAdornment>
+            ),
+          }}
         />
-      </div>
+      </Stack>
 
       {loading ? (
-        <div style={{ textAlign: 'center', padding: 100 }}>
-          <Spin size="large" />
-        </div>
+        <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: 320 }}>
+          <CircularProgress size={36} />
+        </Box>
       ) : data.length === 0 ? (
-        <Empty description="暂无老人档案" />
+        <Card variant="outlined" sx={{ p: 4 }}>
+          <Typography variant="body2" color="text.secondary" align="center">
+            暂无老人档案
+          </Typography>
+        </Card>
       ) : (
-        <Row gutter={[16, 16]}>
-          {data.map((elder) => (
-            <Col key={elder.id} xs={24} sm={12} md={8} lg={6}>
-              <Card
-                hoverable
-                onClick={() => navigate(`/elders/${elder.id}/archive`)}
-                style={{ borderRadius: 8 }}
-              >
-                <Card.Meta
-                  title={elder.name}
-                  description={
-                    <div>
-                      <div style={{ marginBottom: 4 }}>{formatGender(elder.gender)} | {elder.phone || '-'}</div>
-                      <div>
-                        {elder.tags?.map((tag) => (
-                          <Tag key={tag} color="blue" style={{ marginBottom: 4 }}>{tag}</Tag>
-                        ))}
-                      </div>
-                    </div>
-                  }
-                />
-              </Card>
-            </Col>
-          ))}
-        </Row>
+        <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 2 }}>
+          {items}
+        </Box>
       )}
-    </div>
+    </Stack>
   );
 };
 

--- a/frontend/src/pages/elders/ElderArchivePage.tsx
+++ b/frontend/src/pages/elders/ElderArchivePage.tsx
@@ -1,14 +1,19 @@
-import React, { useEffect, useState, useCallback } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
-import { Card, Descriptions, Timeline, Tag, Row, Col, Statistic, Spin, Button, message } from 'antd';
-import { ArrowLeftOutlined } from '@ant-design/icons';
 import {
-  getElderDetail,
-  getHealthRecords,
-  getMedicalRecords,
-  getCareRecords,
-} from '../../api/elders';
+  Box,
+  Button,
+  Card,
+  Chip,
+  CircularProgress,
+  Divider,
+  Stack,
+  Typography,
+} from '@mui/material';
+import ArrowBackRoundedIcon from '@mui/icons-material/ArrowBackRounded';
+import { getElderDetail, getHealthRecords, getMedicalRecords, getCareRecords } from '../../api/elders';
 import { formatGender, formatDate, formatDateTime } from '../../utils/formatter';
+import { message } from '../../utils/message';
 import type { Elder, HealthRecord, MedicalRecord, CareRecord } from '../../types/elder';
 
 interface TimelineEntry {
@@ -16,6 +21,29 @@ interface TimelineEntry {
   type: 'health' | 'medical' | 'care';
   label: string;
   content: string;
+}
+
+function StatCard({
+  label,
+  value,
+  color,
+}: {
+  label: string;
+  value: number;
+  color: string;
+}) {
+  return (
+    <Card variant="outlined" sx={{ flex: 1 }}>
+      <Box sx={{ p: 2.5 }}>
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 0.5 }}>
+          {label}
+        </Typography>
+        <Typography variant="h4" sx={{ color, fontWeight: 700 }}>
+          {value}
+        </Typography>
+      </Box>
+    </Card>
+  );
 }
 
 const ElderArchivePage: React.FC = () => {
@@ -45,30 +73,29 @@ const ElderArchivePage: React.FC = () => {
         care: careRes.data.total,
       });
 
-      // Build unified timeline
       const entries: TimelineEntry[] = [];
-      healthRes.data.items.forEach((r: HealthRecord) => {
+      healthRes.data.items.forEach((record: HealthRecord) => {
         entries.push({
-          time: r.recorded_at,
+          time: record.recorded_at,
           type: 'health',
           label: '健康记录',
-          content: `血压 ${r.blood_pressure_systolic || '-'}/${r.blood_pressure_diastolic || '-'}，心率 ${r.heart_rate || '-'}，血糖 ${r.blood_glucose || '-'}`,
+          content: `血压 ${record.blood_pressure_systolic || '-'}/${record.blood_pressure_diastolic || '-'}，心率 ${record.heart_rate || '-'}，血糖 ${record.blood_glucose || '-'}`,
         });
       });
-      medicalRes.data.items.forEach((r: MedicalRecord) => {
+      medicalRes.data.items.forEach((record: MedicalRecord) => {
         entries.push({
-          time: r.visit_date,
+          time: record.visit_date,
           type: 'medical',
           label: '医疗记录',
-          content: `${r.hospital_name} ${r.department} - ${r.diagnosis}`,
+          content: `${record.hospital_name} ${record.department} - ${record.diagnosis}`,
         });
       });
-      careRes.data.items.forEach((r: CareRecord) => {
+      careRes.data.items.forEach((record: CareRecord) => {
         entries.push({
-          time: r.care_date,
+          time: record.care_date,
           type: 'care',
           label: '照护记录',
-          content: `${r.caregiver_name}: ${r.content}`,
+          content: `${record.caregiver_name}: ${record.content}`,
         });
       });
 
@@ -85,77 +112,164 @@ const ElderArchivePage: React.FC = () => {
     fetchData();
   }, [fetchData]);
 
-  const typeColorMap: Record<string, string> = {
-    health: 'blue',
-    medical: 'green',
-    care: 'orange',
-  };
+  const typeColorMap = useMemo<Record<string, string>>(
+    () => ({
+      health: '#1f6feb',
+      medical: '#1f9d63',
+      care: '#d9822b',
+    }),
+    [],
+  );
 
   if (loading) {
-    return <div style={{ textAlign: 'center', padding: 100 }}><Spin size="large" /></div>;
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: '50vh' }}>
+        <CircularProgress size={36} />
+      </Box>
+    );
   }
 
   return (
-    <div>
+    <Stack spacing={2.5}>
       <Button
-        icon={<ArrowLeftOutlined />}
+        variant="text"
+        startIcon={<ArrowBackRoundedIcon />}
         onClick={() => navigate(-1)}
-        style={{ marginBottom: 16 }}
+        sx={{ alignSelf: 'flex-start' }}
       >
         返回
       </Button>
 
-      <Card title={`${elder?.name || ''} - 健康档案`} style={{ marginBottom: 16 }}>
-        <Descriptions column={{ xs: 1, sm: 2, lg: 3 }}>
-          <Descriptions.Item label="姓名">{elder?.name}</Descriptions.Item>
-          <Descriptions.Item label="性别">{formatGender(elder?.gender)}</Descriptions.Item>
-          <Descriptions.Item label="出生日期">{formatDate(elder?.birth_date)}</Descriptions.Item>
-          <Descriptions.Item label="联系电话">{elder?.phone}</Descriptions.Item>
-          <Descriptions.Item label="地址">{elder?.address}</Descriptions.Item>
-          <Descriptions.Item label="标签">
-            {elder?.tags?.map((t) => <Tag key={t} color="blue">{t}</Tag>) || '-'}
-          </Descriptions.Item>
-        </Descriptions>
+      <Card>
+        <Box sx={{ p: 3 }}>
+          <Typography variant="h5" sx={{ fontWeight: 700, mb: 2 }}>
+            {elder?.name || ''} - 健康档案
+          </Typography>
+          <Box
+            sx={{
+              display: 'grid',
+              gap: 2,
+              gridTemplateColumns: {
+                xs: '1fr',
+                sm: 'repeat(2, minmax(0, 1fr))',
+                lg: 'repeat(3, minmax(0, 1fr))',
+              },
+            }}
+          >
+            <Box>
+              <Typography variant="caption" color="text.secondary">
+                姓名
+              </Typography>
+              <Typography variant="body2">{elder?.name || '-'}</Typography>
+            </Box>
+            <Box>
+              <Typography variant="caption" color="text.secondary">
+                性别
+              </Typography>
+              <Typography variant="body2">{formatGender(elder?.gender)}</Typography>
+            </Box>
+            <Box>
+              <Typography variant="caption" color="text.secondary">
+                出生日期
+              </Typography>
+              <Typography variant="body2">{formatDate(elder?.birth_date)}</Typography>
+            </Box>
+            <Box>
+              <Typography variant="caption" color="text.secondary">
+                联系电话
+              </Typography>
+              <Typography variant="body2">{elder?.phone || '-'}</Typography>
+            </Box>
+            <Box>
+              <Typography variant="caption" color="text.secondary">
+                地址
+              </Typography>
+              <Typography variant="body2">{elder?.address || '-'}</Typography>
+            </Box>
+            <Box>
+              <Typography variant="caption" color="text.secondary">
+                标签
+              </Typography>
+              <Stack direction="row" spacing={1} useFlexGap flexWrap="wrap" sx={{ mt: 0.5 }}>
+                {elder?.tags?.length ? (
+                  elder.tags.map((tag) => (
+                    <Chip key={tag} label={tag} color="primary" variant="outlined" size="small" />
+                  ))
+                ) : (
+                  <Typography variant="body2">-</Typography>
+                )}
+              </Stack>
+            </Box>
+          </Box>
+        </Box>
       </Card>
 
-      <Row gutter={16} style={{ marginBottom: 16 }}>
-        <Col span={8}>
-          <Card>
-            <Statistic title="健康记录数" value={stats.health} valueStyle={{ color: '#1677ff' }} />
-          </Card>
-        </Col>
-        <Col span={8}>
-          <Card>
-            <Statistic title="医疗记录数" value={stats.medical} valueStyle={{ color: '#52c41a' }} />
-          </Card>
-        </Col>
-        <Col span={8}>
-          <Card>
-            <Statistic title="照护记录数" value={stats.care} valueStyle={{ color: '#faad14' }} />
-          </Card>
-        </Col>
-      </Row>
-
-      <Card title="时间线">
-        <Timeline
-          items={timeline.map((entry) => ({
-            color: typeColorMap[entry.type],
-            children: (
-              <div>
-                <div style={{ marginBottom: 4 }}>
-                  <Tag color={typeColorMap[entry.type]}>{entry.label}</Tag>
-                  <span style={{ color: '#8c8c8c', fontSize: 12 }}>
-                    {formatDateTime(entry.time)}
-                  </span>
-                </div>
-                <div>{entry.content}</div>
-              </div>
-            ),
-          }))}
-        />
-        {timeline.length === 0 && <div style={{ textAlign: 'center', color: '#8c8c8c' }}>暂无记录</div>}
+      <Card>
+        <Box sx={{ p: 3 }}>
+          <Typography variant="h6" sx={{ mb: 2 }}>
+            统计概览
+          </Typography>
+          <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2}>
+            <StatCard label="健康记录数" value={stats.health} color="#1f6feb" />
+            <StatCard label="医疗记录数" value={stats.medical} color="#1f9d63" />
+            <StatCard label="照护记录数" value={stats.care} color="#d9822b" />
+          </Stack>
+        </Box>
       </Card>
-    </div>
+
+      <Card>
+        <Box sx={{ p: 3 }}>
+          <Typography variant="h6" sx={{ mb: 2 }}>
+            时间线
+          </Typography>
+          <Stack spacing={2}>
+            {timeline.length ? (
+              timeline.map((entry, index) => (
+                <Box key={`${entry.type}-${entry.time}-${index}`} sx={{ display: 'flex', gap: 2 }}>
+                  <Box
+                    sx={{
+                      width: 12,
+                      display: 'flex',
+                      justifyContent: 'center',
+                    }}
+                  >
+                    <Box
+                      sx={{
+                        width: 12,
+                        height: 12,
+                        borderRadius: '50%',
+                        mt: 0.8,
+                        backgroundColor: typeColorMap[entry.type],
+                        boxShadow: `0 0 0 6px ${typeColorMap[entry.type]}22`,
+                      }}
+                    />
+                  </Box>
+                  <Box sx={{ flex: 1, pb: 2 }}>
+                    <Stack direction="row" spacing={1} alignItems="center" sx={{ mb: 0.5 }}>
+                      <Chip
+                        label={entry.label}
+                        size="small"
+                        variant="outlined"
+                        sx={{ borderColor: typeColorMap[entry.type], color: typeColorMap[entry.type] }}
+                      />
+                      <Typography variant="caption" color="text.secondary">
+                        {formatDateTime(entry.time)}
+                      </Typography>
+                    </Stack>
+                    <Typography variant="body2">{entry.content}</Typography>
+                    {index < timeline.length - 1 && <Divider sx={{ mt: 2 }} />}
+                  </Box>
+                </Box>
+              ))
+            ) : (
+              <Typography variant="body2" color="text.secondary" sx={{ textAlign: 'center', py: 4 }}>
+                暂无记录
+              </Typography>
+            )}
+          </Stack>
+        </Box>
+      </Card>
+    </Stack>
   );
 };
 

--- a/frontend/src/pages/elders/ElderDetailPage.tsx
+++ b/frontend/src/pages/elders/ElderDetailPage.tsx
@@ -1,32 +1,25 @@
-import React, { useEffect, useState, useCallback } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import {
-  Card,
-  Descriptions,
-  Tabs,
-  Table,
+  Box,
   Button,
-  Space,
-  Tag,
-  message,
-  Spin,
-  Upload,
-} from 'antd';
-import { ArrowLeftOutlined, PlusOutlined, UploadOutlined } from '@ant-design/icons';
-import type { ColumnsType } from 'antd/es/table';
+  Card,
+  Chip,
+  CircularProgress,
+  Divider,
+  Stack,
+  Tab,
+  Tabs,
+  Typography,
+} from '@mui/material';
+import ArrowBackRoundedIcon from '@mui/icons-material/ArrowBackRounded';
+import AddRoundedIcon from '@mui/icons-material/AddRounded';
 import AppForm, { type FormFieldConfig } from '../../components/AppForm';
-import {
-  getElderDetail,
-  getHealthRecords,
-  createHealthRecord,
-  importHealthRecords,
-  getMedicalRecords,
-  createMedicalRecord,
-  getCareRecords,
-  createCareRecord,
-} from '../../api/elders';
+import AppTable, { type AppTableColumn } from '../../components/AppTable';
+import UploadFile from '../../components/UploadFile';
+import { importHealthRecords, getElderDetail, getHealthRecords, createHealthRecord, getMedicalRecords, createMedicalRecord, getCareRecords, createCareRecord } from '../../api/elders';
 import { formatGender, formatDate, formatDateTime } from '../../utils/formatter';
-import { getToken } from '../../utils/storage';
+import { message } from '../../utils/message';
 import type { Elder, HealthRecord, MedicalRecord, CareRecord } from '../../types/elder';
 
 const healthRecordFields: FormFieldConfig[] = [
@@ -64,6 +57,24 @@ const careRecordFields: FormFieldConfig[] = [
   { name: 'caregiver_name', label: '照护人员', required: true },
 ];
 
+interface DetailItemProps {
+  label: string;
+  value: React.ReactNode;
+}
+
+function DetailItem({ label, value }: DetailItemProps) {
+  return (
+    <Box>
+      <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 0.5 }}>
+        {label}
+      </Typography>
+      <Typography variant="body2" sx={{ wordBreak: 'break-word' }}>
+        {value}
+      </Typography>
+    </Box>
+  );
+}
+
 const ElderDetailPage: React.FC = () => {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
@@ -74,6 +85,7 @@ const ElderDetailPage: React.FC = () => {
   const [medicalRecords, setMedicalRecords] = useState<MedicalRecord[]>([]);
   const [careRecords, setCareRecords] = useState<CareRecord[]>([]);
   const [loading, setLoading] = useState(true);
+  const [tab, setTab] = useState<'health' | 'medical' | 'care'>('health');
 
   const [healthFormVisible, setHealthFormVisible] = useState(false);
   const [medicalFormVisible, setMedicalFormVisible] = useState(false);
@@ -93,7 +105,7 @@ const ElderDetailPage: React.FC = () => {
       const res = await getHealthRecords(elderId);
       setHealthRecords(res.data.items);
     } catch {
-      // silent
+      // keep the page usable if one record source fails
     }
   }, [elderId]);
 
@@ -102,7 +114,7 @@ const ElderDetailPage: React.FC = () => {
       const res = await getMedicalRecords(elderId);
       setMedicalRecords(res.data.items);
     } catch {
-      // silent
+      // keep the page usable if one record source fails
     }
   }, [elderId]);
 
@@ -111,7 +123,7 @@ const ElderDetailPage: React.FC = () => {
       const res = await getCareRecords(elderId);
       setCareRecords(res.data.items);
     } catch {
-      // silent
+      // keep the page usable if one record source fails
     }
   }, [elderId]);
 
@@ -121,165 +133,271 @@ const ElderDetailPage: React.FC = () => {
       .finally(() => setLoading(false));
   }, [fetchElder, fetchHealthRecords, fetchMedicalRecords, fetchCareRecords]);
 
-  const healthColumns: ColumnsType<HealthRecord> = [
-    { title: '身高(cm)', dataIndex: 'height_cm', width: 100 },
-    { title: '体重(kg)', dataIndex: 'weight_kg', width: 100 },
-    { title: '收缩压', dataIndex: 'blood_pressure_systolic', width: 90 },
-    { title: '舒张压', dataIndex: 'blood_pressure_diastolic', width: 90 },
-    { title: '血糖', dataIndex: 'blood_glucose', width: 80 },
-    { title: '心率', dataIndex: 'heart_rate', width: 80 },
-    { title: '体温', dataIndex: 'temperature', width: 80 },
-    {
-      title: '慢性病',
-      dataIndex: 'chronic_diseases',
-      render: (diseases: string[]) => diseases?.join(', ') || '-',
-    },
-    { title: '记录时间', dataIndex: 'recorded_at', render: formatDateTime, width: 170 },
-  ];
+  const healthColumns = useMemo<AppTableColumn<HealthRecord>[]>(
+    () => [
+      { title: '身高(cm)', dataIndex: 'height_cm', width: 100 },
+      { title: '体重(kg)', dataIndex: 'weight_kg', width: 100 },
+      { title: '收缩压', dataIndex: 'blood_pressure_systolic', width: 90 },
+      { title: '舒张压', dataIndex: 'blood_pressure_diastolic', width: 90 },
+      { title: '血糖', dataIndex: 'blood_glucose', width: 80 },
+      { title: '心率', dataIndex: 'heart_rate', width: 80 },
+      { title: '体温', dataIndex: 'temperature', width: 80 },
+      {
+        title: '慢性病',
+        dataIndex: 'chronic_diseases',
+        render: (value: unknown) => {
+          const diseases = value as string[] | undefined;
+          return diseases?.join(', ') || '-';
+        },
+      },
+      {
+        title: '记录时间',
+        dataIndex: 'recorded_at',
+        render: (value: unknown) => formatDateTime(value as string | undefined | null),
+        width: 170,
+      },
+    ],
+    [],
+  );
 
-  const medicalColumns: ColumnsType<MedicalRecord> = [
-    { title: '就诊日期', dataIndex: 'visit_date', render: formatDate, width: 120 },
-    { title: '医院', dataIndex: 'hospital_name', width: 150 },
-    { title: '科室', dataIndex: 'department', width: 100 },
-    { title: '诊断', dataIndex: 'diagnosis', width: 200 },
-    {
-      title: '用药',
-      dataIndex: 'medications',
-      render: (meds: string[]) =>
-        meds?.map((m) => <Tag key={m}>{m}</Tag>) || '-',
-    },
-    { title: '备注', dataIndex: 'remarks', ellipsis: true },
-  ];
+  const medicalColumns = useMemo<AppTableColumn<MedicalRecord>[]>(
+    () => [
+      {
+        title: '就诊日期',
+        dataIndex: 'visit_date',
+        render: (value: unknown) => formatDate(value as string | undefined | null),
+        width: 120,
+      },
+      { title: '医院', dataIndex: 'hospital_name', width: 150 },
+      { title: '科室', dataIndex: 'department', width: 100 },
+      { title: '诊断', dataIndex: 'diagnosis', width: 200 },
+      {
+        title: '用药',
+        dataIndex: 'medications',
+        render: (value: unknown) => {
+          const meds = value as string[] | undefined;
+          return meds?.length ? (
+            <Stack direction="row" spacing={1} useFlexGap flexWrap="wrap">
+              {meds.map((med) => (
+                <Chip key={med} label={med} size="small" variant="outlined" />
+              ))}
+            </Stack>
+          ) : (
+            '-'
+          );
+        },
+      },
+      { title: '备注', dataIndex: 'remarks', ellipsis: true },
+    ],
+    [],
+  );
 
-  const careColumns: ColumnsType<CareRecord> = [
-    { title: '照护类型', dataIndex: 'care_type', width: 120 },
-    { title: '照护日期', dataIndex: 'care_date', render: formatDate, width: 120 },
-    { title: '照护内容', dataIndex: 'content', ellipsis: true },
-    { title: '照护人员', dataIndex: 'caregiver_name', width: 120 },
-  ];
+  const careColumns = useMemo<AppTableColumn<CareRecord>[]>(
+    () => [
+      { title: '照护类型', dataIndex: 'care_type', width: 120 },
+      {
+        title: '照护日期',
+        dataIndex: 'care_date',
+        render: (value: unknown) => formatDate(value as string | undefined | null),
+        width: 120,
+      },
+      { title: '照护内容', dataIndex: 'content', ellipsis: true },
+      { title: '照护人员', dataIndex: 'caregiver_name', width: 120 },
+    ],
+    [],
+  );
 
   const handleImport = async (file: File) => {
+    await importHealthRecords(elderId, file);
+    message.success('导入成功');
     try {
-      await importHealthRecords(elderId, file);
-      message.success('导入成功');
-      fetchHealthRecords();
-    } catch (err) {
-      message.error(err instanceof Error ? err.message : '导入失败');
+      await fetchHealthRecords();
+    } catch {
+      // import succeeded; keep the success signal even if refresh fails
     }
-    return false; // prevent default upload
   };
 
   if (loading) {
-    return <div style={{ textAlign: 'center', padding: 100 }}><Spin size="large" /></div>;
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: '50vh' }}>
+        <CircularProgress size={36} />
+      </Box>
+    );
   }
 
+  const detailGridSx = {
+    display: 'grid',
+    gap: 2,
+    gridTemplateColumns: {
+      xs: '1fr',
+      sm: 'repeat(2, minmax(0, 1fr))',
+      lg: 'repeat(3, minmax(0, 1fr))',
+    },
+  } as const;
+
   return (
-    <div>
+    <Stack spacing={2.5}>
       <Button
-        icon={<ArrowLeftOutlined />}
+        variant="text"
+        startIcon={<ArrowBackRoundedIcon />}
         onClick={() => navigate('/elders')}
-        style={{ marginBottom: 16 }}
+        sx={{ alignSelf: 'flex-start' }}
       >
         返回列表
       </Button>
 
-      <Card title="基本信息" style={{ marginBottom: 16 }}>
-        <Descriptions column={{ xs: 1, sm: 2, lg: 3 }}>
-          <Descriptions.Item label="姓名">{elder?.name}</Descriptions.Item>
-          <Descriptions.Item label="性别">{formatGender(elder?.gender)}</Descriptions.Item>
-          <Descriptions.Item label="出生日期">{formatDate(elder?.birth_date)}</Descriptions.Item>
-          <Descriptions.Item label="身份证号">{elder?.id_card}</Descriptions.Item>
-          <Descriptions.Item label="联系电话">{elder?.phone}</Descriptions.Item>
-          <Descriptions.Item label="地址">{elder?.address}</Descriptions.Item>
-          <Descriptions.Item label="紧急联系人">{elder?.emergency_contact_name || '-'}</Descriptions.Item>
-          <Descriptions.Item label="紧急联系电话">{elder?.emergency_contact_phone || '-'}</Descriptions.Item>
-          <Descriptions.Item label="标签">
-            {elder?.tags?.map((t) => <Tag key={t} color="blue">{t}</Tag>) || '-'}
-          </Descriptions.Item>
-        </Descriptions>
+      <Card>
+        <Box sx={{ p: 3 }}>
+          <Typography variant="h5" sx={{ mb: 2, fontWeight: 700 }}>
+            {elder?.name || '老人档案'}
+          </Typography>
+          <Box sx={detailGridSx}>
+            <DetailItem label="姓名" value={elder?.name || '-'} />
+            <DetailItem label="性别" value={formatGender(elder?.gender)} />
+            <DetailItem label="出生日期" value={formatDate(elder?.birth_date)} />
+            <DetailItem label="身份证号" value={elder?.id_card || '-'} />
+            <DetailItem label="联系电话" value={elder?.phone || '-'} />
+            <DetailItem label="地址" value={elder?.address || '-'} />
+            <DetailItem label="紧急联系人" value={elder?.emergency_contact_name || '-'} />
+            <DetailItem label="紧急联系电话" value={elder?.emergency_contact_phone || '-'} />
+            <DetailItem
+              label="标签"
+              value={
+                elder?.tags?.length ? (
+                  <Stack direction="row" spacing={1} useFlexGap flexWrap="wrap">
+                    {elder.tags.map((tag) => (
+                      <Chip key={tag} label={tag} color="primary" variant="outlined" size="small" />
+                    ))}
+                  </Stack>
+                ) : (
+                  '-'
+                )
+              }
+            />
+          </Box>
+        </Box>
       </Card>
 
       <Card>
-        <Tabs
-          defaultActiveKey="health"
-          items={[
-            {
-              key: 'health',
-              label: '健康记录',
-              children: (
-                <>
-                  <Space style={{ marginBottom: 16 }}>
-                    <Button
-                      type="primary"
-                      icon={<PlusOutlined />}
-                      onClick={() => setHealthFormVisible(true)}
-                    >
-                      新增健康记录
-                    </Button>
-                    <Upload
-                      accept=".csv,.xlsx,.xls"
-                      showUploadList={false}
-                      headers={{ Authorization: `Bearer ${getToken() || ''}` }}
-                      beforeUpload={(file) => { handleImport(file); return false; }}
-                    >
-                      <Button icon={<UploadOutlined />}>导入数据</Button>
-                    </Upload>
-                  </Space>
-                  <Table<HealthRecord>
-                    columns={healthColumns}
-                    dataSource={healthRecords}
-                    rowKey="id"
-                    scroll={{ x: 'max-content' }}
-                  />
-                </>
-              ),
-            },
-            {
-              key: 'medical',
-              label: '医疗记录',
-              children: (
-                <>
+        <Box sx={{ p: 3 }}>
+          <Typography variant="h6" sx={{ mb: 2 }}>
+            记录概览
+          </Typography>
+          <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2}>
+            <Card variant="outlined" sx={{ flex: 1 }}>
+              <Box sx={{ p: 2.5 }}>
+                <Typography variant="body2" color="text.secondary" sx={{ mb: 0.5 }}>
+                  健康记录数
+                </Typography>
+                <Typography variant="h4" color="primary.main">
+                  {healthRecords.length}
+                </Typography>
+              </Box>
+            </Card>
+            <Card variant="outlined" sx={{ flex: 1 }}>
+              <Box sx={{ p: 2.5 }}>
+                <Typography variant="body2" color="text.secondary" sx={{ mb: 0.5 }}>
+                  医疗记录数
+                </Typography>
+                <Typography variant="h4" color="success.main">
+                  {medicalRecords.length}
+                </Typography>
+              </Box>
+            </Card>
+            <Card variant="outlined" sx={{ flex: 1 }}>
+              <Box sx={{ p: 2.5 }}>
+                <Typography variant="body2" color="text.secondary" sx={{ mb: 0.5 }}>
+                  照护记录数
+                </Typography>
+                <Typography variant="h4" color="warning.main">
+                  {careRecords.length}
+                </Typography>
+              </Box>
+            </Card>
+          </Stack>
+        </Box>
+      </Card>
+
+      <Card>
+        <Box sx={{ px: 3, pt: 2 }}>
+          <Tabs
+            value={tab}
+            onChange={(_, nextTab: 'health' | 'medical' | 'care') => setTab(nextTab)}
+          >
+            <Tab value="health" label="健康记录" />
+            <Tab value="medical" label="医疗记录" />
+            <Tab value="care" label="照护记录" />
+          </Tabs>
+        </Box>
+        <Divider />
+        <Box sx={{ p: 3 }}>
+          {tab === 'health' && (
+            <AppTable<HealthRecord>
+              columns={healthColumns}
+              dataSource={healthRecords}
+              rowKey="id"
+              loading={false}
+              pagination={false}
+              emptyText="暂无健康记录"
+              toolbar={
+                <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1.5} useFlexGap flexWrap="wrap">
                   <Button
-                    type="primary"
-                    icon={<PlusOutlined />}
-                    onClick={() => setMedicalFormVisible(true)}
-                    style={{ marginBottom: 16 }}
+                    variant="contained"
+                    startIcon={<AddRoundedIcon />}
+                    onClick={() => setHealthFormVisible(true)}
                   >
-                    新增医疗记录
+                    新增健康记录
                   </Button>
-                  <Table<MedicalRecord>
-                    columns={medicalColumns}
-                    dataSource={medicalRecords}
-                    rowKey="id"
-                    scroll={{ x: 'max-content' }}
+                  <UploadFile
+                    accept=".csv,.xlsx,.xls"
+                    buttonText="导入数据"
+                    onUpload={handleImport}
                   />
-                </>
-              ),
-            },
-            {
-              key: 'care',
-              label: '照护记录',
-              children: (
-                <>
-                  <Button
-                    type="primary"
-                    icon={<PlusOutlined />}
-                    onClick={() => setCareFormVisible(true)}
-                    style={{ marginBottom: 16 }}
-                  >
-                    新增照护记录
-                  </Button>
-                  <Table<CareRecord>
-                    columns={careColumns}
-                    dataSource={careRecords}
-                    rowKey="id"
-                    scroll={{ x: 'max-content' }}
-                  />
-                </>
-              ),
-            },
-          ]}
-        />
+                </Stack>
+              }
+            />
+          )}
+
+          {tab === 'medical' && (
+            <AppTable<MedicalRecord>
+              columns={medicalColumns}
+              dataSource={medicalRecords}
+              rowKey="id"
+              loading={false}
+              pagination={false}
+              emptyText="暂无医疗记录"
+              toolbar={
+                <Button
+                  variant="contained"
+                  startIcon={<AddRoundedIcon />}
+                  onClick={() => setMedicalFormVisible(true)}
+                >
+                  新增医疗记录
+                </Button>
+              }
+            />
+          )}
+
+          {tab === 'care' && (
+            <AppTable<CareRecord>
+              columns={careColumns}
+              dataSource={careRecords}
+              rowKey="id"
+              loading={false}
+              pagination={false}
+              emptyText="暂无照护记录"
+              toolbar={
+                <Button
+                  variant="contained"
+                  startIcon={<AddRoundedIcon />}
+                  onClick={() => setCareFormVisible(true)}
+                >
+                  新增照护记录
+                </Button>
+              }
+            />
+          )}
+        </Box>
       </Card>
 
       <AppForm
@@ -323,7 +441,7 @@ const ElderDetailPage: React.FC = () => {
         }}
         onCancel={() => setCareFormVisible(false)}
       />
-    </div>
+    </Stack>
   );
 };
 

--- a/frontend/src/pages/elders/ElderListPage.tsx
+++ b/frontend/src/pages/elders/ElderListPage.tsx
@@ -1,15 +1,43 @@
-import React, { useState, useCallback } from 'react';
-import { Button, Tag, Space, Popconfirm, Select, message } from 'antd';
-import { PlusOutlined, EyeOutlined, EditOutlined, DeleteOutlined } from '@ant-design/icons';
+import React, { useCallback, useMemo, useState } from 'react';
+import {
+  Button,
+  Chip,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+  Stack,
+  type SelectChangeEvent,
+} from '@mui/material';
+import AddRoundedIcon from '@mui/icons-material/AddRounded';
+import DeleteRoundedIcon from '@mui/icons-material/DeleteRounded';
+import EditRoundedIcon from '@mui/icons-material/EditRounded';
+import LockResetRoundedIcon from '@mui/icons-material/LockResetRounded';
+import ToggleOnRoundedIcon from '@mui/icons-material/ToggleOnRounded';
+import VerifiedUserRoundedIcon from '@mui/icons-material/VerifiedUserRounded';
+import VisibilityRoundedIcon from '@mui/icons-material/VisibilityRounded';
 import { useNavigate } from 'react-router-dom';
-import type { ColumnsType } from 'antd/es/table';
-import AppTable from '../../components/AppTable';
+import AppTable, { type AppTableColumn } from '../../components/AppTable';
 import AppForm, { type FormFieldConfig } from '../../components/AppForm';
 import PermissionGuard from '../../components/PermissionGuard';
 import { useTable } from '../../hooks/useTable';
-import { getElders, createElder, updateElder, deleteElder, resetElderPassword, updateElderAccountStatus, activateElderAccount } from '../../api/elders';
-import { formatGender, formatDate } from '../../utils/formatter';
-import { GENDER_OPTIONS, RISK_LEVEL_OPTIONS, ACCOUNT_STATUS_OPTIONS } from '../../utils/constants';
+import {
+  activateElderAccount,
+  createElder,
+  deleteElder,
+  getElders,
+  resetElderPassword,
+  updateElder,
+  updateElderAccountStatus,
+} from '../../api/elders';
+import { formatDate, formatGender } from '../../utils/formatter';
+import { ACCOUNT_STATUS_OPTIONS, GENDER_OPTIONS, RISK_LEVEL_OPTIONS } from '../../utils/constants';
+import { message } from '../../utils/message';
 import type { Elder, ElderListQuery } from '../../types/elder';
 
 const formFields: FormFieldConfig[] = [
@@ -23,11 +51,18 @@ const formFields: FormFieldConfig[] = [
   { name: 'emergency_contact_phone', label: '紧急联系电话' },
 ];
 
+interface ConfirmState {
+  title: string;
+  content: string;
+  onConfirm: () => Promise<void> | void;
+}
+
 const ElderListPage: React.FC = () => {
   const navigate = useNavigate();
   const [formVisible, setFormVisible] = useState(false);
   const [editingElder, setEditingElder] = useState<Elder | null>(null);
   const [submitLoading, setSubmitLoading] = useState(false);
+  const [confirmState, setConfirmState] = useState<ConfirmState | null>(null);
 
   const fetchFn = useCallback(
     (params: ElderListQuery & { page: number; page_size: number }) => getElders(params),
@@ -46,6 +81,12 @@ const ElderListPage: React.FC = () => {
     setEditingElder(record);
     setFormVisible(true);
   };
+
+  const openConfirm = useCallback((title: string, content: string, onConfirm: () => Promise<void> | void) => {
+    setConfirmState({ title, content, onConfirm });
+  }, []);
+
+  const closeConfirm = () => setConfirmState(null);
 
   const handleDelete = async (id: number) => {
     try {
@@ -107,130 +148,226 @@ const ElderListPage: React.FC = () => {
     }
   };
 
-  const columns: ColumnsType<Elder> = [
-    { title: '姓名', dataIndex: 'name', width: 100 },
-    { title: '性别', dataIndex: 'gender', width: 80, render: formatGender },
-    { title: '出生日期', dataIndex: 'birth_date', width: 120, render: formatDate },
-    { title: '联系电话', dataIndex: 'phone', width: 130 },
-    { title: '地址', dataIndex: 'address', width: 200, ellipsis: true },
-    {
-      title: '标签',
-      dataIndex: 'tags',
-      width: 200,
-      render: (tags: string[]) =>
-        tags?.map((tag) => <Tag key={tag} color="blue">{tag}</Tag>),
-    },
-    {
-      title: '账户名',
-      dataIndex: 'username',
-      width: 130,
-      render: (val: string | undefined) => val || <Tag>未激活</Tag>,
-    },
-    {
-      title: '家属数',
-      dataIndex: 'family_count',
-      width: 80,
-      render: (val: number | undefined) => val ?? 0,
-    },
-    {
-      title: '账户状态',
-      dataIndex: 'account_status',
-      width: 100,
-      render: (status: string) => (
-        <Tag color={status === 'active' ? 'green' : 'red'}>
-          {status === 'active' ? '正常' : '已禁用'}
-        </Tag>
-      ),
-    },
-    {
-      title: '操作',
-      key: 'actions',
-      width: 360,
-      fixed: 'right',
-      render: (_, record) => (
-        <Space>
-          <Button
-            type="link"
-            size="small"
-            icon={<EyeOutlined />}
-            onClick={() => navigate(`/elders/${record.id}`)}
-          >
-            查看
-          </Button>
-          <PermissionGuard permission="elder:update">
-            <Button
-              type="link"
+  const columns = useMemo<AppTableColumn<Elder>[]>(
+    () => [
+      { title: '姓名', dataIndex: 'name', width: 100 },
+      {
+        title: '性别',
+        dataIndex: 'gender',
+        width: 80,
+        render: (value: unknown) => formatGender(value as string | undefined | null),
+      },
+      {
+        title: '出生日期',
+        dataIndex: 'birth_date',
+        width: 120,
+        render: (value: unknown) => formatDate(value as string | undefined | null),
+      },
+      { title: '联系电话', dataIndex: 'phone', width: 130 },
+      { title: '地址', dataIndex: 'address', width: 200, ellipsis: true },
+      {
+        title: '标签',
+        dataIndex: 'tags',
+        width: 220,
+        render: (value: unknown) => {
+          const tags = value as string[] | undefined;
+          return tags?.length ? (
+            <Stack direction="row" spacing={1} useFlexGap flexWrap="wrap">
+              {tags.map((tag) => (
+                <Chip key={tag} label={tag} color="primary" variant="outlined" size="small" />
+              ))}
+            </Stack>
+          ) : (
+            '-'
+          );
+        },
+      },
+      {
+        title: '账户名',
+        dataIndex: 'username',
+        width: 130,
+        render: (value: unknown) => {
+          const val = value as string | undefined;
+          return val || <Chip label="未激活" size="small" />;
+        },
+      },
+      {
+        title: '家属数',
+        dataIndex: 'family_count',
+        width: 80,
+        render: (value: unknown) => {
+          const val = value as number | undefined;
+          return val ?? 0;
+        },
+      },
+      {
+        title: '账户状态',
+        dataIndex: 'account_status',
+        width: 100,
+        render: (value: unknown) => {
+          const status = value as string;
+          return (
+            <Chip
+              label={status === 'active' ? '正常' : '已禁用'}
+              color={status === 'active' ? 'success' : 'error'}
               size="small"
-              icon={<EditOutlined />}
-              onClick={() => handleEdit(record)}
+              variant="outlined"
+            />
+          );
+        },
+      },
+      {
+        title: '操作',
+        key: 'actions',
+        width: 380,
+        fixed: 'right' as const,
+        render: (_: unknown, record: Elder) => (
+          <Stack direction="row" spacing={1} useFlexGap flexWrap="wrap">
+            <Button
+              size="small"
+              variant="text"
+              startIcon={<VisibilityRoundedIcon />}
+              onClick={() => navigate(`/elders/${record.id}`)}
             >
-              编辑
+              查看
             </Button>
-          </PermissionGuard>
-          <PermissionGuard permission="elder:update">
-            {!record.username ? (
-              <Popconfirm title="确定为该老人激活登录账户？" onConfirm={() => handleActivateAccount(record)}>
-                <Button type="link" size="small">激活账户</Button>
-              </Popconfirm>
-            ) : (
-              <>
-                <Popconfirm title="确定重置密码？" onConfirm={() => handleResetPassword(record.id)}>
-                  <Button type="link" size="small">重置密码</Button>
-                </Popconfirm>
-                <Popconfirm
-                  title={`确定${record.account_status === 'active' ? '禁用' : '启用'}该账户？`}
-                  onConfirm={() => handleToggleStatus(record.id, record.account_status)}
+            <PermissionGuard permission="elder:update">
+              <Button
+                size="small"
+                variant="text"
+                startIcon={<EditRoundedIcon />}
+                onClick={() => handleEdit(record)}
+              >
+                编辑
+              </Button>
+            </PermissionGuard>
+            <PermissionGuard permission="elder:update">
+              {!record.username ? (
+                <Button
+                  size="small"
+                  variant="text"
+                  color="info"
+                  startIcon={<VerifiedUserRoundedIcon />}
+                  onClick={() =>
+                    openConfirm('激活账户', '确定为该老人激活登录账户？', () =>
+                      handleActivateAccount(record),
+                    )
+                  }
                 >
+                  激活账户
+                </Button>
+              ) : (
+                <>
                   <Button
-                    type="link"
                     size="small"
-                    danger={record.account_status === 'active'}
+                    variant="text"
+                    startIcon={<LockResetRoundedIcon />}
+                    onClick={() =>
+                      openConfirm('重置密码', '确定重置密码？', () => handleResetPassword(record.id))
+                    }
+                  >
+                    重置密码
+                  </Button>
+                  <Button
+                    size="small"
+                    variant="text"
+                    color={record.account_status === 'active' ? 'warning' : 'success'}
+                    startIcon={<ToggleOnRoundedIcon />}
+                    onClick={() =>
+                      openConfirm(
+                        record.account_status === 'active' ? '禁用账户' : '启用账户',
+                        `确定${record.account_status === 'active' ? '禁用' : '启用'}该账户？`,
+                        () => handleToggleStatus(record.id, record.account_status),
+                      )
+                    }
                   >
                     {record.account_status === 'active' ? '禁用' : '启用'}
                   </Button>
-                </Popconfirm>
-              </>
-            )}
-          </PermissionGuard>
-          <PermissionGuard permission="elder:delete">
-            <Popconfirm title="确定删除该老人档案？" onConfirm={() => handleDelete(record.id)}>
-              <Button type="link" size="small" danger icon={<DeleteOutlined />}>
+                </>
+              )}
+            </PermissionGuard>
+            <PermissionGuard permission="elder:delete">
+              <Button
+                size="small"
+                variant="text"
+                color="error"
+                startIcon={<DeleteRoundedIcon />}
+                onClick={() =>
+                  openConfirm('删除老人档案', '确定删除该老人档案？', () => handleDelete(record.id))
+                }
+              >
                 删除
               </Button>
-            </Popconfirm>
-          </PermissionGuard>
-        </Space>
-      ),
-    },
-  ];
+            </PermissionGuard>
+          </Stack>
+        ),
+      },
+    ],
+    [navigate, openConfirm],
+  );
 
   const filterBar = (
-    <Space wrap>
-      <Select
-        placeholder="性别"
-        allowClear
-        options={GENDER_OPTIONS}
-        style={{ width: 100 }}
-        value={query.gender || undefined}
-        onChange={(val) => setQuery((prev) => ({ ...prev, gender: val }))}
-      />
-      <Select
-        placeholder="风险等级"
-        allowClear
-        options={RISK_LEVEL_OPTIONS}
-        style={{ width: 120 }}
-        value={query.risk_level || undefined}
-        onChange={(val) => setQuery((prev) => ({ ...prev, risk_level: val }))}
-      />
-      <Select
-        placeholder="账户状态"
-        allowClear
-        options={ACCOUNT_STATUS_OPTIONS}
-        style={{ width: 120 }}
-        value={query.account_status || undefined}
-        onChange={(val) => setQuery((prev) => ({ ...prev, account_status: val }))}
-      />
-    </Space>
+    <Stack direction={{ xs: 'column', md: 'row' }} spacing={1.5} useFlexGap flexWrap="wrap">
+      <FormControl size="small" sx={{ minWidth: 120 }}>
+        <InputLabel>性别</InputLabel>
+        <Select
+          label="性别"
+          value={query.gender || ''}
+          onChange={(event: SelectChangeEvent) =>
+            setQuery((prev) => ({ ...prev, gender: event.target.value || undefined }))
+          }
+        >
+          <MenuItem value="">全部</MenuItem>
+          {GENDER_OPTIONS.map((option) => (
+            <MenuItem key={option.value} value={option.value}>
+              {option.label}
+            </MenuItem>
+          ))}
+        </Select>
+      </FormControl>
+
+      <FormControl size="small" sx={{ minWidth: 140 }}>
+        <InputLabel>风险等级</InputLabel>
+        <Select
+          label="风险等级"
+          value={query.risk_level || ''}
+          onChange={(event: SelectChangeEvent) =>
+            setQuery((prev) => ({ ...prev, risk_level: event.target.value || undefined }))
+          }
+        >
+          <MenuItem value="">全部</MenuItem>
+          {RISK_LEVEL_OPTIONS.map((option) => (
+            <MenuItem key={option.value} value={option.value}>
+              {option.label}
+            </MenuItem>
+          ))}
+        </Select>
+      </FormControl>
+
+      <FormControl size="small" sx={{ minWidth: 140 }}>
+        <InputLabel>账户状态</InputLabel>
+        <Select
+          label="账户状态"
+          value={query.account_status || ''}
+          onChange={(event: SelectChangeEvent) =>
+            setQuery((prev) => ({ ...prev, account_status: event.target.value || undefined }))
+          }
+        >
+          <MenuItem value="">全部</MenuItem>
+          {ACCOUNT_STATUS_OPTIONS.map((option) => (
+            <MenuItem key={option.value} value={option.value}>
+              {option.label}
+            </MenuItem>
+          ))}
+        </Select>
+      </FormControl>
+
+      <PermissionGuard permission="elder:create">
+        <Button variant="contained" startIcon={<AddRoundedIcon />} onClick={handleCreate}>
+          新增老人
+        </Button>
+      </PermissionGuard>
+    </Stack>
   );
 
   return (
@@ -243,16 +380,7 @@ const ElderListPage: React.FC = () => {
         onChange={handleTableChange}
         onSearch={handleSearch}
         searchPlaceholder="搜索姓名/手机号/身份证"
-        toolbar={
-          <Space>
-            {filterBar}
-            <PermissionGuard permission="elder:create">
-              <Button type="primary" icon={<PlusOutlined />} onClick={handleCreate}>
-                新增老人
-              </Button>
-            </PermissionGuard>
-          </Space>
-        }
+        toolbar={filterBar}
       />
 
       <AppForm
@@ -265,6 +393,29 @@ const ElderListPage: React.FC = () => {
         confirmLoading={submitLoading}
         width={600}
       />
+
+      <Dialog open={Boolean(confirmState)} onClose={closeConfirm}>
+        <DialogTitle>{confirmState?.title}</DialogTitle>
+        <DialogContent>
+          <DialogContentText>{confirmState?.content}</DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={closeConfirm} color="inherit">
+            取消
+          </Button>
+          <Button
+            onClick={async () => {
+              const action = confirmState?.onConfirm;
+              closeConfirm();
+              await action?.();
+            }}
+            color="error"
+            variant="contained"
+          >
+            确认
+          </Button>
+        </DialogActions>
+      </Dialog>
     </>
   );
 };

--- a/frontend/src/pages/family-portal/FamilyElderHealthPage.tsx
+++ b/frontend/src/pages/family-portal/FamilyElderHealthPage.tsx
@@ -1,11 +1,21 @@
-import React, { useEffect, useState, useCallback } from 'react';
-import { Card, Tabs, Table, Spin, Empty, Descriptions, Tag, Typography } from 'antd';
-import { HeartOutlined, AlertOutlined } from '@ant-design/icons';
-import type { ColumnsType } from 'antd/es/table';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  Box,
+  Card,
+  CardContent,
+  Chip,
+  CircularProgress,
+  Stack,
+  Tab,
+  Tabs,
+  Typography,
+} from '@mui/material';
+import FavoriteRoundedIcon from '@mui/icons-material/FavoriteRounded';
+import WarningAmberRoundedIcon from '@mui/icons-material/WarningAmberRounded';
 import { getFamilySelf, getFamilyElder, getElderHealthRecords, getElderAlerts } from '../../api/family';
 import type { FamilyMemberInfo, FamilyElderInfo } from '../../types/family';
-
-const { Text } = Typography;
+import AppTable, { type AppTableColumn } from '../../components/AppTable';
+import { formatDateTime } from '../../utils/formatter';
 
 interface HealthRecord {
   id: number;
@@ -29,10 +39,10 @@ interface AlertRecord {
   created_at: string;
 }
 
-const alertLevelColorMap: Record<string, string> = {
-  high: 'red',
-  medium: 'orange',
-  low: 'blue',
+const alertLevelColorMap: Record<string, 'error' | 'warning' | 'primary'> = {
+  high: 'error',
+  medium: 'warning',
+  low: 'primary',
 };
 
 const alertStatusLabelMap: Record<string, string> = {
@@ -42,7 +52,7 @@ const alertStatusLabelMap: Record<string, string> = {
   closed: '已关闭',
 };
 
-const healthColumns: ColumnsType<HealthRecord> = [
+const healthColumns: AppTableColumn<HealthRecord>[] = [
   {
     title: '记录日期',
     dataIndex: 'record_date',
@@ -78,7 +88,7 @@ const healthColumns: ColumnsType<HealthRecord> = [
     render: (val?: number) => val ?? '-',
   },
   {
-    title: '体温 (*C)',
+    title: '体温 (°C)',
     dataIndex: 'temperature',
     key: 'temperature',
     width: 100,
@@ -93,7 +103,7 @@ const healthColumns: ColumnsType<HealthRecord> = [
   },
 ];
 
-const alertColumns: ColumnsType<AlertRecord> = [
+const alertColumns: AppTableColumn<AlertRecord>[] = [
   {
     title: '预警类型',
     dataIndex: 'alert_type',
@@ -104,9 +114,9 @@ const alertColumns: ColumnsType<AlertRecord> = [
     title: '级别',
     dataIndex: 'level',
     key: 'level',
-    width: 80,
+    width: 100,
     render: (level: string) => (
-      <Tag color={alertLevelColorMap[level] || 'default'}>{level}</Tag>
+      <Chip size="small" color={alertLevelColorMap[level] || 'primary'} label={level} />
     ),
   },
   {
@@ -119,7 +129,7 @@ const alertColumns: ColumnsType<AlertRecord> = [
     title: '状态',
     dataIndex: 'status',
     key: 'status',
-    width: 100,
+    width: 110,
     render: (status: string) => alertStatusLabelMap[status] || status,
   },
   {
@@ -127,6 +137,7 @@ const alertColumns: ColumnsType<AlertRecord> = [
     dataIndex: 'created_at',
     key: 'created_at',
     width: 180,
+    render: (value) => formatDateTime(value as string | undefined),
   },
 ];
 
@@ -142,16 +153,14 @@ const FamilyElderHealthPage: React.FC = () => {
   const [alertsTotal, setAlertsTotal] = useState(0);
   const [healthPage, setHealthPage] = useState(1);
   const [alertsPage, setAlertsPage] = useState(1);
+  const [tab, setTab] = useState<'health' | 'alerts'>('health');
   const pageSize = 10;
 
   useEffect(() => {
     const fetchBaseData = async () => {
       setLoading(true);
       try {
-        const [selfRes, elderRes] = await Promise.all([
-          getFamilySelf(),
-          getFamilyElder(),
-        ]);
+        const [selfRes, elderRes] = await Promise.all([getFamilySelf(), getFamilyElder()]);
         setFamilyInfo(selfRes.data as FamilyMemberInfo);
         setElderInfo(elderRes.data as FamilyElderInfo);
       } catch {
@@ -160,165 +169,201 @@ const FamilyElderHealthPage: React.FC = () => {
         setLoading(false);
       }
     };
-    fetchBaseData();
+    void fetchBaseData();
   }, []);
 
-  const fetchHealthRecords = useCallback(async (page: number) => {
-    if (!familyInfo) return;
-    setHealthLoading(true);
-    try {
-      const res = await getElderHealthRecords(familyInfo.elder_id, {
-        page,
-        page_size: pageSize,
-      });
-      const data = res.data as { items: HealthRecord[]; total: number };
-      setHealthRecords(data.items || []);
-      setHealthTotal(data.total || 0);
-    } catch {
-      // Error handled by http interceptor
-    } finally {
-      setHealthLoading(false);
-    }
-  }, [familyInfo]);
+  const fetchHealthRecords = useCallback(
+    async (page: number) => {
+      if (!familyInfo) return;
+      setHealthLoading(true);
+      try {
+        const res = await getElderHealthRecords(familyInfo.elder_id, {
+          page,
+          page_size: pageSize,
+        });
+        const data = res.data as { items: HealthRecord[]; total: number };
+        setHealthRecords(data.items || []);
+        setHealthTotal(data.total || 0);
+      } catch {
+        // Error handled by http interceptor
+      } finally {
+        setHealthLoading(false);
+      }
+    },
+    [familyInfo],
+  );
 
-  const fetchAlerts = useCallback(async (page: number) => {
-    if (!familyInfo) return;
-    setAlertsLoading(true);
-    try {
-      const res = await getElderAlerts({
-        elder_id: familyInfo.elder_id,
-        page,
-        page_size: pageSize,
-      });
-      const data = res.data as { items: AlertRecord[]; total: number };
-      setAlerts(data.items || []);
-      setAlertsTotal(data.total || 0);
-    } catch {
-      // Error handled by http interceptor
-    } finally {
-      setAlertsLoading(false);
-    }
-  }, [familyInfo]);
+  const fetchAlerts = useCallback(
+    async (page: number) => {
+      if (!familyInfo) return;
+      setAlertsLoading(true);
+      try {
+        const res = await getElderAlerts({
+          elder_id: familyInfo.elder_id,
+          page,
+          page_size: pageSize,
+        });
+        const data = res.data as { items: AlertRecord[]; total: number };
+        setAlerts(data.items || []);
+        setAlertsTotal(data.total || 0);
+      } catch {
+        // Error handled by http interceptor
+      } finally {
+        setAlertsLoading(false);
+      }
+    },
+    [familyInfo],
+  );
 
-  // Fetch health records when familyInfo is ready or page changes
   useEffect(() => {
     if (familyInfo) {
-      fetchHealthRecords(healthPage);
+      void fetchHealthRecords(healthPage);
     }
   }, [familyInfo, healthPage, fetchHealthRecords]);
 
-  // Fetch alerts when familyInfo is ready or page changes
   useEffect(() => {
     if (familyInfo) {
-      fetchAlerts(alertsPage);
+      void fetchAlerts(alertsPage);
     }
   }, [familyInfo, alertsPage, fetchAlerts]);
 
   if (loading) {
     return (
-      <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '50vh' }}>
-        <Spin size="large" />
-      </div>
+      <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: '50vh' }}>
+        <CircularProgress size={44} />
+      </Box>
     );
   }
 
-  const tabItems = [
+  const tabs = [
     {
-      key: 'health',
-      label: (
-        <span>
-          <HeartOutlined style={{ marginRight: 4 }} />
-          健康记录
-        </span>
-      ),
-      children: (
-        <Spin spinning={healthLoading}>
-          {healthRecords.length === 0 && !healthLoading ? (
-            <Empty description="暂无健康记录" />
-          ) : (
-            <Table<HealthRecord>
+      value: 'health',
+      label: '健康记录',
+      icon: <FavoriteRoundedIcon fontSize="small" />,
+    },
+    {
+      value: 'alerts',
+      label: '风险预警',
+      icon: <WarningAmberRoundedIcon fontSize="small" />,
+    },
+  ] as const;
+
+  return (
+    <Stack spacing={3}>
+      {elderInfo && (
+        <Card>
+          <CardContent>
+            <Stack spacing={2}>
+              <Stack direction="row" spacing={1.5} alignItems="center">
+                <FavoriteRoundedIcon color="error" />
+                <Typography variant="h6" sx={{ fontWeight: 700 }}>
+                  {elderInfo.name} 的健康信息
+                </Typography>
+              </Stack>
+
+              <Box
+                sx={{
+                  display: 'grid',
+                  gridTemplateColumns: { xs: '1fr', sm: 'repeat(3, minmax(0, 1fr))' },
+                  gap: 2,
+                }}
+              >
+                <Box sx={{ p: 2, borderRadius: 2, bgcolor: 'background.default' }}>
+                  <Typography variant="body2" color="text.secondary">
+                    性别
+                  </Typography>
+                  <Typography variant="subtitle1" sx={{ mt: 0.5, fontWeight: 600 }}>
+                    {elderInfo.gender}
+                  </Typography>
+                </Box>
+                <Box sx={{ p: 2, borderRadius: 2, bgcolor: 'background.default' }}>
+                  <Typography variant="body2" color="text.secondary">
+                    联系电话
+                  </Typography>
+                  <Typography variant="subtitle1" sx={{ mt: 0.5, fontWeight: 600 }}>
+                    {elderInfo.phone}
+                  </Typography>
+                </Box>
+                <Box sx={{ p: 2, borderRadius: 2, bgcolor: 'background.default' }}>
+                  <Typography variant="body2" color="text.secondary">
+                    住址
+                  </Typography>
+                  <Typography variant="subtitle1" sx={{ mt: 0.5, fontWeight: 600 }}>
+                    {elderInfo.address}
+                  </Typography>
+                </Box>
+              </Box>
+
+              {elderInfo.tags.length > 0 && (
+                <Stack direction="row" spacing={1} useFlexGap flexWrap="wrap">
+                  {elderInfo.tags.map((tag) => (
+                    <Chip key={tag} color="primary" variant="outlined" label={tag} />
+                  ))}
+                </Stack>
+              )}
+            </Stack>
+          </CardContent>
+        </Card>
+      )}
+
+      <Card>
+        <CardContent>
+          <Tabs
+            value={tab}
+            onChange={(_, nextValue) => setTab(nextValue)}
+            variant="scrollable"
+            scrollButtons="auto"
+            sx={{ borderBottom: 1, borderColor: 'divider', mb: 2 }}
+          >
+            {tabs.map((item) => (
+              <Tab
+                key={item.value}
+                value={item.value}
+                icon={item.icon}
+                iconPosition="start"
+                label={item.label}
+              />
+            ))}
+          </Tabs>
+
+          {tab === 'health' ? (
+            <AppTable<HealthRecord>
               columns={healthColumns}
               dataSource={healthRecords}
+              loading={healthLoading}
               rowKey="id"
               pagination={{
                 current: healthPage,
                 pageSize,
                 total: healthTotal,
-                onChange: (page) => setHealthPage(page),
                 showTotal: (total) => `共 ${total} 条`,
               }}
-              scroll={{ x: 800 }}
+              onChange={({ current }) => {
+                if (current) setHealthPage(current);
+              }}
+              emptyText="暂无健康记录"
             />
-          )}
-        </Spin>
-      ),
-    },
-    {
-      key: 'alerts',
-      label: (
-        <span>
-          <AlertOutlined style={{ marginRight: 4 }} />
-          风险预警
-        </span>
-      ),
-      children: (
-        <Spin spinning={alertsLoading}>
-          {alerts.length === 0 && !alertsLoading ? (
-            <Empty description="暂无风险预警" />
           ) : (
-            <Table<AlertRecord>
+            <AppTable<AlertRecord>
               columns={alertColumns}
               dataSource={alerts}
+              loading={alertsLoading}
               rowKey="id"
               pagination={{
                 current: alertsPage,
                 pageSize,
                 total: alertsTotal,
-                onChange: (page) => setAlertsPage(page),
                 showTotal: (total) => `共 ${total} 条`,
               }}
-              scroll={{ x: 700 }}
+              onChange={({ current }) => {
+                if (current) setAlertsPage(current);
+              }}
+              emptyText="暂无风险预警"
             />
           )}
-        </Spin>
-      ),
-    },
-  ];
-
-  return (
-    <div>
-      {/* Elder info header */}
-      {elderInfo && (
-        <Card style={{ marginBottom: 24 }}>
-          <Descriptions
-            title={
-              <span>
-                <HeartOutlined style={{ marginRight: 8, color: '#ff4d4f' }} />
-                {elderInfo.name} 的健康信息
-              </span>
-            }
-            column={{ xs: 1, sm: 3 }}
-          >
-            <Descriptions.Item label="性别">{elderInfo.gender}</Descriptions.Item>
-            <Descriptions.Item label="联系电话">{elderInfo.phone}</Descriptions.Item>
-            <Descriptions.Item label="住址">{elderInfo.address}</Descriptions.Item>
-          </Descriptions>
-          {elderInfo.tags.length > 0 && (
-            <div style={{ marginTop: 8 }}>
-              <Text strong style={{ marginRight: 8 }}>标签：</Text>
-              {elderInfo.tags.map((tag) => (
-                <Tag key={tag} color="blue">{tag}</Tag>
-              ))}
-            </div>
-          )}
-        </Card>
-      )}
-
-      {/* Tabbed health data */}
-      <Card>
-        <Tabs items={tabItems} />
+        </CardContent>
       </Card>
-    </div>
+    </Stack>
   );
 };
 

--- a/frontend/src/pages/family-portal/FamilyElderHealthPage.tsx
+++ b/frontend/src/pages/family-portal/FamilyElderHealthPage.tsx
@@ -1,11 +1,21 @@
-import React, { useEffect, useState, useCallback } from 'react';
-import { Card, Tabs, Table, Spin, Empty, Descriptions, Tag, Typography } from 'antd';
-import { HeartOutlined, AlertOutlined } from '@ant-design/icons';
-import type { ColumnsType } from 'antd/es/table';
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  Box,
+  Card,
+  CardContent,
+  Chip,
+  CircularProgress,
+  Stack,
+  Tab,
+  Tabs,
+  Typography,
+} from '@mui/material';
+import FavoriteRoundedIcon from '@mui/icons-material/FavoriteRounded';
+import WarningAmberRoundedIcon from '@mui/icons-material/WarningAmberRounded';
 import { getFamilySelf, getFamilyElder, getElderHealthRecords, getElderAlerts } from '../../api/family';
 import type { FamilyMemberInfo, FamilyElderInfo } from '../../types/family';
-
-const { Text } = Typography;
+import AppTable, { type AppTableColumn } from '../../components/AppTable';
+import { formatDateTime } from '../../utils/formatter';
 
 interface HealthRecord {
   id: number;
@@ -29,10 +39,10 @@ interface AlertRecord {
   created_at: string;
 }
 
-const alertLevelColorMap: Record<string, string> = {
-  high: 'red',
-  medium: 'orange',
-  low: 'blue',
+const alertLevelColorMap: Record<string, 'error' | 'warning' | 'primary'> = {
+  high: 'error',
+  medium: 'warning',
+  low: 'primary',
 };
 
 const alertStatusLabelMap: Record<string, string> = {
@@ -42,7 +52,7 @@ const alertStatusLabelMap: Record<string, string> = {
   closed: '已关闭',
 };
 
-const healthColumns: ColumnsType<HealthRecord> = [
+const healthColumns: AppTableColumn<HealthRecord>[] = [
   {
     title: '记录日期',
     dataIndex: 'record_date',
@@ -54,46 +64,46 @@ const healthColumns: ColumnsType<HealthRecord> = [
     dataIndex: 'systolic_bp',
     key: 'systolic_bp',
     width: 130,
-    render: (val?: number) => val ?? '-',
+    render: (value) => (typeof value === 'number' ? value : '-'),
   },
   {
     title: '舒张压 (mmHg)',
     dataIndex: 'diastolic_bp',
     key: 'diastolic_bp',
     width: 130,
-    render: (val?: number) => val ?? '-',
+    render: (value) => (typeof value === 'number' ? value : '-'),
   },
   {
     title: '血糖 (mmol/L)',
     dataIndex: 'blood_glucose',
     key: 'blood_glucose',
     width: 130,
-    render: (val?: number) => val ?? '-',
+    render: (value) => (typeof value === 'number' ? value : '-'),
   },
   {
     title: '心率 (bpm)',
     dataIndex: 'heart_rate',
     key: 'heart_rate',
     width: 110,
-    render: (val?: number) => val ?? '-',
+    render: (value) => (typeof value === 'number' ? value : '-'),
   },
   {
-    title: '体温 (*C)',
+    title: '体温 (°C)',
     dataIndex: 'temperature',
     key: 'temperature',
     width: 100,
-    render: (val?: number) => val ?? '-',
+    render: (value) => (typeof value === 'number' ? value : '-'),
   },
   {
     title: '备注',
     dataIndex: 'notes',
     key: 'notes',
     ellipsis: true,
-    render: (val?: string) => val || '-',
+    render: (value) => (typeof value === 'string' && value ? value : '-'),
   },
 ];
 
-const alertColumns: ColumnsType<AlertRecord> = [
+const alertColumns: AppTableColumn<AlertRecord>[] = [
   {
     title: '预警类型',
     dataIndex: 'alert_type',
@@ -104,10 +114,11 @@ const alertColumns: ColumnsType<AlertRecord> = [
     title: '级别',
     dataIndex: 'level',
     key: 'level',
-    width: 80,
-    render: (level: string) => (
-      <Tag color={alertLevelColorMap[level] || 'default'}>{level}</Tag>
-    ),
+    width: 100,
+    render: (value) => {
+      const level = typeof value === 'string' ? value : '';
+      return <Chip size="small" color={alertLevelColorMap[level] || 'primary'} label={level || '-'} />;
+    },
   },
   {
     title: '内容',
@@ -119,14 +130,18 @@ const alertColumns: ColumnsType<AlertRecord> = [
     title: '状态',
     dataIndex: 'status',
     key: 'status',
-    width: 100,
-    render: (status: string) => alertStatusLabelMap[status] || status,
+    width: 110,
+    render: (value) => {
+      const status = typeof value === 'string' ? value : '';
+      return alertStatusLabelMap[status] || status || '-';
+    },
   },
   {
     title: '时间',
     dataIndex: 'created_at',
     key: 'created_at',
     width: 180,
+    render: (value) => formatDateTime(value as string | undefined),
   },
 ];
 
@@ -142,16 +157,14 @@ const FamilyElderHealthPage: React.FC = () => {
   const [alertsTotal, setAlertsTotal] = useState(0);
   const [healthPage, setHealthPage] = useState(1);
   const [alertsPage, setAlertsPage] = useState(1);
+  const [tab, setTab] = useState<'health' | 'alerts'>('health');
   const pageSize = 10;
 
   useEffect(() => {
     const fetchBaseData = async () => {
       setLoading(true);
       try {
-        const [selfRes, elderRes] = await Promise.all([
-          getFamilySelf(),
-          getFamilyElder(),
-        ]);
+        const [selfRes, elderRes] = await Promise.all([getFamilySelf(), getFamilyElder()]);
         setFamilyInfo(selfRes.data as FamilyMemberInfo);
         setElderInfo(elderRes.data as FamilyElderInfo);
       } catch {
@@ -160,165 +173,201 @@ const FamilyElderHealthPage: React.FC = () => {
         setLoading(false);
       }
     };
-    fetchBaseData();
+    void fetchBaseData();
   }, []);
 
-  const fetchHealthRecords = useCallback(async (page: number) => {
-    if (!familyInfo) return;
-    setHealthLoading(true);
-    try {
-      const res = await getElderHealthRecords(familyInfo.elder_id, {
-        page,
-        page_size: pageSize,
-      });
-      const data = res.data as { items: HealthRecord[]; total: number };
-      setHealthRecords(data.items || []);
-      setHealthTotal(data.total || 0);
-    } catch {
-      // Error handled by http interceptor
-    } finally {
-      setHealthLoading(false);
-    }
-  }, [familyInfo]);
+  const fetchHealthRecords = useCallback(
+    async (page: number) => {
+      if (!familyInfo) return;
+      setHealthLoading(true);
+      try {
+        const res = await getElderHealthRecords(familyInfo.elder_id, {
+          page,
+          page_size: pageSize,
+        });
+        const data = res.data as { items: HealthRecord[]; total: number };
+        setHealthRecords(data.items || []);
+        setHealthTotal(data.total || 0);
+      } catch {
+        // Error handled by http interceptor
+      } finally {
+        setHealthLoading(false);
+      }
+    },
+    [familyInfo],
+  );
 
-  const fetchAlerts = useCallback(async (page: number) => {
-    if (!familyInfo) return;
-    setAlertsLoading(true);
-    try {
-      const res = await getElderAlerts({
-        elder_id: familyInfo.elder_id,
-        page,
-        page_size: pageSize,
-      });
-      const data = res.data as { items: AlertRecord[]; total: number };
-      setAlerts(data.items || []);
-      setAlertsTotal(data.total || 0);
-    } catch {
-      // Error handled by http interceptor
-    } finally {
-      setAlertsLoading(false);
-    }
-  }, [familyInfo]);
+  const fetchAlerts = useCallback(
+    async (page: number) => {
+      if (!familyInfo) return;
+      setAlertsLoading(true);
+      try {
+        const res = await getElderAlerts({
+          elder_id: familyInfo.elder_id,
+          page,
+          page_size: pageSize,
+        });
+        const data = res.data as { items: AlertRecord[]; total: number };
+        setAlerts(data.items || []);
+        setAlertsTotal(data.total || 0);
+      } catch {
+        // Error handled by http interceptor
+      } finally {
+        setAlertsLoading(false);
+      }
+    },
+    [familyInfo],
+  );
 
-  // Fetch health records when familyInfo is ready or page changes
   useEffect(() => {
     if (familyInfo) {
-      fetchHealthRecords(healthPage);
+      void fetchHealthRecords(healthPage);
     }
   }, [familyInfo, healthPage, fetchHealthRecords]);
 
-  // Fetch alerts when familyInfo is ready or page changes
   useEffect(() => {
     if (familyInfo) {
-      fetchAlerts(alertsPage);
+      void fetchAlerts(alertsPage);
     }
   }, [familyInfo, alertsPage, fetchAlerts]);
 
   if (loading) {
     return (
-      <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '50vh' }}>
-        <Spin size="large" />
-      </div>
+      <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: '50vh' }}>
+        <CircularProgress size={44} />
+      </Box>
     );
   }
 
-  const tabItems = [
+  const tabs = [
     {
-      key: 'health',
-      label: (
-        <span>
-          <HeartOutlined style={{ marginRight: 4 }} />
-          健康记录
-        </span>
-      ),
-      children: (
-        <Spin spinning={healthLoading}>
-          {healthRecords.length === 0 && !healthLoading ? (
-            <Empty description="暂无健康记录" />
-          ) : (
-            <Table<HealthRecord>
+      value: 'health',
+      label: '健康记录',
+      icon: <FavoriteRoundedIcon fontSize="small" />,
+    },
+    {
+      value: 'alerts',
+      label: '风险预警',
+      icon: <WarningAmberRoundedIcon fontSize="small" />,
+    },
+  ] as const;
+
+  return (
+    <Stack spacing={3}>
+      {elderInfo && (
+        <Card>
+          <CardContent>
+            <Stack spacing={2}>
+              <Stack direction="row" spacing={1.5} alignItems="center">
+                <FavoriteRoundedIcon color="error" />
+                <Typography variant="h6" sx={{ fontWeight: 700 }}>
+                  {elderInfo.name} 的健康信息
+                </Typography>
+              </Stack>
+
+              <Box
+                sx={{
+                  display: 'grid',
+                  gridTemplateColumns: { xs: '1fr', sm: 'repeat(3, minmax(0, 1fr))' },
+                  gap: 2,
+                }}
+              >
+                <Box sx={{ p: 2, borderRadius: 2, bgcolor: 'background.default' }}>
+                  <Typography variant="body2" color="text.secondary">
+                    性别
+                  </Typography>
+                  <Typography variant="subtitle1" sx={{ mt: 0.5, fontWeight: 600 }}>
+                    {elderInfo.gender}
+                  </Typography>
+                </Box>
+                <Box sx={{ p: 2, borderRadius: 2, bgcolor: 'background.default' }}>
+                  <Typography variant="body2" color="text.secondary">
+                    联系电话
+                  </Typography>
+                  <Typography variant="subtitle1" sx={{ mt: 0.5, fontWeight: 600 }}>
+                    {elderInfo.phone}
+                  </Typography>
+                </Box>
+                <Box sx={{ p: 2, borderRadius: 2, bgcolor: 'background.default' }}>
+                  <Typography variant="body2" color="text.secondary">
+                    住址
+                  </Typography>
+                  <Typography variant="subtitle1" sx={{ mt: 0.5, fontWeight: 600 }}>
+                    {elderInfo.address}
+                  </Typography>
+                </Box>
+              </Box>
+
+              {elderInfo.tags.length > 0 && (
+                <Stack direction="row" spacing={1} useFlexGap flexWrap="wrap">
+                  {elderInfo.tags.map((tag) => (
+                    <Chip key={tag} color="primary" variant="outlined" label={tag} />
+                  ))}
+                </Stack>
+              )}
+            </Stack>
+          </CardContent>
+        </Card>
+      )}
+
+      <Card>
+        <CardContent>
+          <Tabs
+            value={tab}
+            onChange={(_, nextValue) => setTab(nextValue)}
+            variant="scrollable"
+            scrollButtons="auto"
+            sx={{ borderBottom: 1, borderColor: 'divider', mb: 2 }}
+          >
+            {tabs.map((item) => (
+              <Tab
+                key={item.value}
+                value={item.value}
+                icon={item.icon}
+                iconPosition="start"
+                label={item.label}
+              />
+            ))}
+          </Tabs>
+
+          {tab === 'health' ? (
+            <AppTable<HealthRecord>
               columns={healthColumns}
               dataSource={healthRecords}
+              loading={healthLoading}
               rowKey="id"
               pagination={{
                 current: healthPage,
                 pageSize,
                 total: healthTotal,
-                onChange: (page) => setHealthPage(page),
                 showTotal: (total) => `共 ${total} 条`,
               }}
-              scroll={{ x: 800 }}
+              onChange={({ current }) => {
+                if (current) setHealthPage(current);
+              }}
+              emptyText="暂无健康记录"
             />
-          )}
-        </Spin>
-      ),
-    },
-    {
-      key: 'alerts',
-      label: (
-        <span>
-          <AlertOutlined style={{ marginRight: 4 }} />
-          风险预警
-        </span>
-      ),
-      children: (
-        <Spin spinning={alertsLoading}>
-          {alerts.length === 0 && !alertsLoading ? (
-            <Empty description="暂无风险预警" />
           ) : (
-            <Table<AlertRecord>
+            <AppTable<AlertRecord>
               columns={alertColumns}
               dataSource={alerts}
+              loading={alertsLoading}
               rowKey="id"
               pagination={{
                 current: alertsPage,
                 pageSize,
                 total: alertsTotal,
-                onChange: (page) => setAlertsPage(page),
                 showTotal: (total) => `共 ${total} 条`,
               }}
-              scroll={{ x: 700 }}
+              onChange={({ current }) => {
+                if (current) setAlertsPage(current);
+              }}
+              emptyText="暂无风险预警"
             />
           )}
-        </Spin>
-      ),
-    },
-  ];
-
-  return (
-    <div>
-      {/* Elder info header */}
-      {elderInfo && (
-        <Card style={{ marginBottom: 24 }}>
-          <Descriptions
-            title={
-              <span>
-                <HeartOutlined style={{ marginRight: 8, color: '#ff4d4f' }} />
-                {elderInfo.name} 的健康信息
-              </span>
-            }
-            column={{ xs: 1, sm: 3 }}
-          >
-            <Descriptions.Item label="性别">{elderInfo.gender}</Descriptions.Item>
-            <Descriptions.Item label="联系电话">{elderInfo.phone}</Descriptions.Item>
-            <Descriptions.Item label="住址">{elderInfo.address}</Descriptions.Item>
-          </Descriptions>
-          {elderInfo.tags.length > 0 && (
-            <div style={{ marginTop: 8 }}>
-              <Text strong style={{ marginRight: 8 }}>标签：</Text>
-              {elderInfo.tags.map((tag) => (
-                <Tag key={tag} color="blue">{tag}</Tag>
-              ))}
-            </div>
-          )}
-        </Card>
-      )}
-
-      {/* Tabbed health data */}
-      <Card>
-        <Tabs items={tabItems} />
+        </CardContent>
       </Card>
-    </div>
+    </Stack>
   );
 };
 

--- a/frontend/src/pages/family-portal/FamilyHomePage.tsx
+++ b/frontend/src/pages/family-portal/FamilyHomePage.tsx
@@ -1,11 +1,34 @@
 import React, { useEffect, useState } from 'react';
-import { Card, Spin, Tag, Button, Descriptions, Typography } from 'antd';
-import { HeartOutlined, PhoneOutlined, HomeOutlined } from '@ant-design/icons';
+import {
+  Box,
+  Button,
+  Card,
+  CardContent,
+  Chip,
+  CircularProgress,
+  Stack,
+  Typography,
+} from '@mui/material';
+import FavoriteRoundedIcon from '@mui/icons-material/FavoriteRounded';
+import PhoneRoundedIcon from '@mui/icons-material/PhoneRounded';
+import HomeRoundedIcon from '@mui/icons-material/HomeRounded';
+import ArrowForwardRoundedIcon from '@mui/icons-material/ArrowForwardRounded';
 import { useNavigate } from 'react-router-dom';
 import { getFamilySelf, getFamilyElder } from '../../api/family';
 import type { FamilyMemberInfo, FamilyElderInfo } from '../../types/family';
 
-const { Title, Text } = Typography;
+function InfoRow({ label, value }: { label: string; value: React.ReactNode }) {
+  return (
+    <Box sx={{ p: 2, borderRadius: 2, bgcolor: 'background.default' }}>
+      <Typography variant="body2" color="text.secondary">
+        {label}
+      </Typography>
+      <Typography variant="subtitle1" sx={{ mt: 0.5, fontWeight: 600 }}>
+        {value}
+      </Typography>
+    </Box>
+  );
+}
 
 const FamilyHomePage: React.FC = () => {
   const navigate = useNavigate();
@@ -17,10 +40,7 @@ const FamilyHomePage: React.FC = () => {
     const fetchData = async () => {
       setLoading(true);
       try {
-        const [selfRes, elderRes] = await Promise.all([
-          getFamilySelf(),
-          getFamilyElder(),
-        ]);
+        const [selfRes, elderRes] = await Promise.all([getFamilySelf(), getFamilyElder()]);
         setFamilyInfo(selfRes.data as FamilyMemberInfo);
         setElderInfo(elderRes.data as FamilyElderInfo);
       } catch {
@@ -29,85 +49,110 @@ const FamilyHomePage: React.FC = () => {
         setLoading(false);
       }
     };
-    fetchData();
+    void fetchData();
   }, []);
 
   if (loading) {
     return (
-      <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '50vh' }}>
-        <Spin size="large" />
-      </div>
+      <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: '50vh' }}>
+        <CircularProgress size={44} />
+      </Box>
     );
   }
 
   return (
-    <div style={{ maxWidth: 900, margin: '0 auto' }}>
-      {/* Welcome card */}
-      <Card style={{ marginBottom: 24 }}>
-        <Title level={4} style={{ margin: 0 }}>
-          您好，{familyInfo?.real_name}
-        </Title>
-        <Text type="secondary" style={{ marginTop: 4, display: 'block' }}>
-          关系：{familyInfo?.relationship} | 关联老人：{familyInfo?.elder_name}
-        </Text>
+    <Stack spacing={3}>
+      <Card>
+        <CardContent>
+          <Stack spacing={1.5}>
+            <Typography variant="h5" sx={{ fontWeight: 800 }}>
+              您好，{familyInfo?.real_name}
+            </Typography>
+            <Typography variant="body2" color="text.secondary">
+              关系：{familyInfo?.relationship} | 关联老人：{familyInfo?.elder_name}
+            </Typography>
+          </Stack>
+        </CardContent>
       </Card>
 
-      {/* Elder info card */}
       {elderInfo && (
-        <Card
-          title={
-            <span>
-              <HeartOutlined style={{ marginRight: 8, color: '#ff4d4f' }} />
-              老人基本信息
-            </span>
-          }
-          style={{ marginBottom: 24 }}
-        >
-          <Descriptions column={{ xs: 1, sm: 2 }} labelStyle={{ fontWeight: 500 }}>
-            <Descriptions.Item label="姓名">{elderInfo.name}</Descriptions.Item>
-            <Descriptions.Item label="性别">{elderInfo.gender}</Descriptions.Item>
-            {elderInfo.birth_date && (
-              <Descriptions.Item label="出生日期">{elderInfo.birth_date}</Descriptions.Item>
-            )}
-            <Descriptions.Item label="联系电话">
-              <PhoneOutlined style={{ marginRight: 4 }} />
-              {elderInfo.phone}
-            </Descriptions.Item>
-            <Descriptions.Item label="住址" span={2}>
-              <HomeOutlined style={{ marginRight: 4 }} />
-              {elderInfo.address}
-            </Descriptions.Item>
-            <Descriptions.Item label="紧急联系人">
-              {elderInfo.emergency_contact_name}
-            </Descriptions.Item>
-            <Descriptions.Item label="紧急联系电话">
-              {elderInfo.emergency_contact_phone}
-            </Descriptions.Item>
-          </Descriptions>
+        <Card>
+          <CardContent>
+            <Stack spacing={2.5}>
+              <Stack direction="row" spacing={1.5} alignItems="center">
+                <FavoriteRoundedIcon color="error" />
+                <Typography variant="h6" sx={{ fontWeight: 700 }}>
+                  老人基本信息
+                </Typography>
+              </Stack>
 
-          {elderInfo.tags.length > 0 && (
-            <div style={{ marginTop: 16 }}>
-              <Text strong style={{ marginRight: 8 }}>标签：</Text>
-              {elderInfo.tags.map((tag) => (
-                <Tag key={tag} color="blue">{tag}</Tag>
-              ))}
-            </div>
-          )}
+              <Box
+                sx={{
+                  display: 'grid',
+                  gridTemplateColumns: { xs: '1fr', sm: 'repeat(2, minmax(0, 1fr))' },
+                  gap: 2,
+                }}
+              >
+                <InfoRow label="姓名" value={elderInfo.name} />
+                <InfoRow label="性别" value={elderInfo.gender} />
+                {elderInfo.birth_date && <InfoRow label="出生日期" value={elderInfo.birth_date} />}
+                <InfoRow
+                  label="联系电话"
+                  value={
+                    <Stack direction="row" spacing={0.75} alignItems="center">
+                      <PhoneRoundedIcon fontSize="small" />
+                      <span>{elderInfo.phone}</span>
+                    </Stack>
+                  }
+                />
+                <InfoRow
+                  label="住址"
+                  value={
+                    <Stack direction="row" spacing={0.75} alignItems="center">
+                      <HomeRoundedIcon fontSize="small" />
+                      <span>{elderInfo.address}</span>
+                    </Stack>
+                  }
+                />
+                <InfoRow label="紧急联系人" value={elderInfo.emergency_contact_name} />
+                <InfoRow label="紧急联系电话" value={elderInfo.emergency_contact_phone} />
+              </Box>
+
+              {elderInfo.tags.length > 0 && (
+                <Stack direction="row" spacing={1} useFlexGap flexWrap="wrap">
+                  {elderInfo.tags.map((tag) => (
+                    <Chip key={tag} color="primary" variant="outlined" label={tag} />
+                  ))}
+                </Stack>
+              )}
+            </Stack>
+          </CardContent>
         </Card>
       )}
 
-      {/* Quick links */}
       <Card>
-        <Button
-          type="primary"
-          icon={<HeartOutlined />}
-          size="large"
-          onClick={() => navigate('/family/elder')}
-        >
-          查看老人健康记录
-        </Button>
+        <CardContent>
+          <Stack direction={{ xs: 'column', sm: 'row' }} alignItems={{ sm: 'center' }} spacing={2}>
+            <Box sx={{ flex: 1 }}>
+              <Typography variant="h6" sx={{ fontWeight: 700 }}>
+                查看老人健康记录
+              </Typography>
+              <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
+                进入健康页查看最近的体征数据和预警信息。
+              </Typography>
+            </Box>
+            <Button
+              variant="contained"
+              size="large"
+              startIcon={<ArrowForwardRoundedIcon />}
+              onClick={() => navigate('/family/elder')}
+            >
+              打开健康页
+            </Button>
+          </Stack>
+        </CardContent>
       </Card>
-    </div>
+    </Stack>
   );
 };
 

--- a/frontend/src/pages/family/FamilyMemberPage.tsx
+++ b/frontend/src/pages/family/FamilyMemberPage.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from 'react';
-import type { ColumnsType } from 'antd/es/table';
-import AppTable from '../../components/AppTable';
+import { Chip } from '@mui/material';
+import AppTable, { type AppTableColumn } from '../../components/AppTable';
 import { useTable } from '../../hooks/useTable';
 import { getFamilyMembers } from '../../api/family';
 import { formatDateTime } from '../../utils/formatter';
@@ -16,12 +16,19 @@ const FamilyMemberPage: React.FC = () => {
   const { data, loading, pagination, handleTableChange, handleSearch } =
     useTable<FamilyMemberAdmin, PaginationParams>(fetchFn);
 
-  const columns: ColumnsType<FamilyMemberAdmin> = [
+  const columns: AppTableColumn<FamilyMemberAdmin>[] = [
     { title: '用户名', dataIndex: 'username', width: 130 },
     { title: '姓名', dataIndex: 'real_name', width: 100 },
     { title: '手机号', dataIndex: 'phone', width: 130 },
     { title: '关联老人', dataIndex: 'elder_name', width: 120 },
-    { title: '关系', dataIndex: 'relationship', width: 100 },
+    {
+      title: '关系',
+      dataIndex: 'relationship',
+      width: 100,
+      render: (relationship: string) => (
+        <Chip size="small" label={relationship || '-'} variant="outlined" />
+      ),
+    },
     { title: '注册时间', dataIndex: 'created_at', render: formatDateTime, width: 170 },
   ];
 

--- a/frontend/src/pages/family/FamilyMemberPage.tsx
+++ b/frontend/src/pages/family/FamilyMemberPage.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from 'react';
-import type { ColumnsType } from 'antd/es/table';
-import AppTable from '../../components/AppTable';
+import { Chip } from '@mui/material';
+import AppTable, { type AppTableColumn } from '../../components/AppTable';
 import { useTable } from '../../hooks/useTable';
 import { getFamilyMembers } from '../../api/family';
 import { formatDateTime } from '../../utils/formatter';
@@ -16,13 +16,26 @@ const FamilyMemberPage: React.FC = () => {
   const { data, loading, pagination, handleTableChange, handleSearch } =
     useTable<FamilyMemberAdmin, PaginationParams>(fetchFn);
 
-  const columns: ColumnsType<FamilyMemberAdmin> = [
+  const columns: AppTableColumn<FamilyMemberAdmin>[] = [
     { title: '用户名', dataIndex: 'username', width: 130 },
     { title: '姓名', dataIndex: 'real_name', width: 100 },
     { title: '手机号', dataIndex: 'phone', width: 130 },
     { title: '关联老人', dataIndex: 'elder_name', width: 120 },
-    { title: '关系', dataIndex: 'relationship', width: 100 },
-    { title: '注册时间', dataIndex: 'created_at', render: formatDateTime, width: 170 },
+    {
+      title: '关系',
+      dataIndex: 'relationship',
+      width: 100,
+      render: (value) => {
+        const relationship = String(value ?? '');
+        return <Chip size="small" label={relationship || '-'} variant="outlined" />;
+      },
+    },
+    {
+      title: '注册时间',
+      dataIndex: 'created_at',
+      render: (value) => formatDateTime(value as string | null | undefined),
+      width: 170,
+    },
   ];
 
   return (

--- a/frontend/src/pages/family/FamilyRegisterPage.tsx
+++ b/frontend/src/pages/family/FamilyRegisterPage.tsx
@@ -1,16 +1,29 @@
-import React, { useState, useMemo, useEffect, useCallback } from 'react';
-import { Form, Input, Button, Card, Select, message } from 'antd';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import {
-  KeyOutlined,
-  UserOutlined,
-  PhoneOutlined,
-  LockOutlined,
-  TeamOutlined,
-} from '@ant-design/icons';
+  Alert,
+  Box,
+  Button,
+  Card,
+  CardContent,
+  FormControl,
+  InputAdornment,
+  InputLabel,
+  MenuItem,
+  Select,
+  Stack,
+  TextField,
+  Typography,
+} from '@mui/material';
+import KeyRoundedIcon from '@mui/icons-material/KeyRounded';
+import PersonOutlineRoundedIcon from '@mui/icons-material/PersonOutlineRounded';
+import PhoneRoundedIcon from '@mui/icons-material/PhoneRounded';
+import LockOutlinedIcon from '@mui/icons-material/LockOutlined';
+import GroupsRoundedIcon from '@mui/icons-material/GroupsRounded';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import SlideCaptcha from '../../components/SlideCaptcha';
 import { validateInviteCode, registerFamily } from '../../api/family';
 import type { InviteCodeValidation } from '../../types/family';
+import { message } from '../../utils/message';
 
 interface RegisterFormValues {
   invite_code: string;
@@ -21,6 +34,8 @@ interface RegisterFormValues {
   relationship: string;
 }
 
+type RegisterFormErrors = Partial<Record<keyof RegisterFormValues, string>>;
+
 const relationshipOptions = [
   { value: '子女', label: '子女' },
   { value: '配偶', label: '配偶' },
@@ -28,19 +43,29 @@ const relationshipOptions = [
   { value: '其他', label: '其他' },
 ];
 
+const initialValues: RegisterFormValues = {
+  invite_code: '',
+  real_name: '',
+  phone: '',
+  password: '',
+  confirm_password: '',
+  relationship: '',
+};
+
 const FamilyRegisterPage: React.FC = () => {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
-  const [form] = Form.useForm<RegisterFormValues>();
   const [loading, setLoading] = useState(false);
   const [captchaVisible, setCaptchaVisible] = useState(false);
   const [codeValidation, setCodeValidation] = useState<InviteCodeValidation | null>(null);
   const [validating, setValidating] = useState(false);
+  const [values, setValues] = useState<RegisterFormValues>(initialValues);
+  const [errors, setErrors] = useState<RegisterFormErrors>({});
 
   const sessionId = useMemo(() => crypto.randomUUID(), []);
 
   const doValidateCode = useCallback(async (code: string) => {
-    if (!code || code.trim().length === 0) {
+    if (!code.trim()) {
       setCodeValidation(null);
       return;
     }
@@ -55,40 +80,120 @@ const FamilyRegisterPage: React.FC = () => {
     }
   }, []);
 
-  // Auto-fill and validate from URL query parameter
+  const ensureInviteCodeValid = useCallback(async (code: string) => {
+    setValidating(true);
+    try {
+      const res = await validateInviteCode(code);
+      const data = res.data as InviteCodeValidation;
+      setCodeValidation(data);
+      return data.valid;
+    } catch {
+      setCodeValidation({ valid: false, elder_name: '', remaining_slots: 0 });
+      return false;
+    } finally {
+      setValidating(false);
+    }
+  }, []);
+
+  const validateValues = useCallback((nextValues: RegisterFormValues) => {
+    const nextErrors: RegisterFormErrors = {};
+
+    if (!nextValues.invite_code.trim()) {
+      nextErrors.invite_code = '请输入邀请码';
+    }
+    if (!nextValues.real_name.trim()) {
+      nextErrors.real_name = '请输入姓名';
+    }
+    if (!nextValues.phone.trim()) {
+      nextErrors.phone = '请输入手机号';
+    } else if (!/^1\d{10}$/.test(nextValues.phone.trim())) {
+      nextErrors.phone = '请输入正确的手机号';
+    }
+    if (!nextValues.password) {
+      nextErrors.password = '请设置密码';
+    } else if (nextValues.password.length < 6) {
+      nextErrors.password = '密码至少6位';
+    }
+    if (!nextValues.confirm_password) {
+      nextErrors.confirm_password = '请确认密码';
+    } else if (nextValues.confirm_password !== nextValues.password) {
+      nextErrors.confirm_password = '两次密码不一致';
+    }
+    if (!nextValues.relationship) {
+      nextErrors.relationship = '请选择与老人的关系';
+    }
+
+    return nextErrors;
+  }, []);
+
+  const updateField = <K extends keyof RegisterFormValues>(key: K, value: RegisterFormValues[K]) => {
+    setValues((current) => {
+      const next = { ...current, [key]: value };
+      if (
+        key === 'password'
+        && current.confirm_password
+        && current.confirm_password !== value
+      ) {
+        setErrors((previous) => ({
+          ...previous,
+          confirm_password: '两次密码不一致',
+        }));
+      }
+      return next;
+    });
+    setErrors((current) => ({
+      ...current,
+      [key]: '',
+    }));
+  };
+
   useEffect(() => {
     const code = searchParams.get('code');
     if (code) {
-      form.setFieldsValue({ invite_code: code });
-      doValidateCode(code);
+      setValues((current) => ({
+        ...current,
+        invite_code: code,
+      }));
+      void doValidateCode(code);
     }
-  }, [searchParams, form, doValidateCode]);
+  }, [searchParams, doValidateCode]);
 
-  const handleCodeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const value = e.target.value;
-    if (value.length >= 8) {
-      doValidateCode(value);
+  const handleCodeChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const value = event.target.value;
+    updateField('invite_code', value);
+    if (value.trim().length >= 8) {
+      void doValidateCode(value);
     } else {
       setCodeValidation(null);
     }
   };
 
   const handleCodeBlur = () => {
-    const code = form.getFieldValue('invite_code') as string;
-    if (code && code.trim().length > 0) {
-      doValidateCode(code);
+    const code = values.invite_code;
+    if (code.trim()) {
+      void doValidateCode(code);
     }
   };
 
-  const handleSubmit = () => {
-    form.validateFields().then(() => {
-      setCaptchaVisible(true);
-    });
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const nextErrors = validateValues(values);
+    setErrors(nextErrors);
+    if (Object.keys(nextErrors).length > 0) {
+      return;
+    }
+
+    const isValid = await ensureInviteCodeValid(values.invite_code.trim());
+    if (!isValid) {
+      message.error('邀请码无效');
+      return;
+    }
+
+    setCaptchaVisible(true);
   };
 
   const handleCaptchaSuccess = async (captchaToken: string) => {
     setCaptchaVisible(false);
-    const values = form.getFieldsValue();
     setLoading(true);
     try {
       await registerFamily({
@@ -114,135 +219,161 @@ const FamilyRegisterPage: React.FC = () => {
   };
 
   return (
-    <>
+    <Box sx={{ width: '100%', maxWidth: 560 }}>
       <Card
-        style={{
-          width: 480,
-          borderRadius: 12,
-          boxShadow: '0 8px 32px rgba(0, 0, 0, 0.15)',
+        sx={{
+          overflow: 'hidden',
+          border: '1px solid',
+          borderColor: 'divider',
         }}
-        styles={{ body: { padding: '40px 32px' } }}
       >
-        <div style={{ textAlign: 'center', marginBottom: 32 }}>
-          <h1
-            style={{
-              fontSize: 22,
-              fontWeight: 700,
-              color: '#1677ff',
-              margin: 0,
-              lineHeight: 1.4,
-            }}
-          >
-            家属注册
-          </h1>
-          <p style={{ color: '#8c8c8c', fontSize: 14, margin: '8px 0 0' }}>
-            智慧医养大数据公共服务平台
-          </p>
-        </div>
+        <CardContent sx={{ p: { xs: 3, sm: 4 } }}>
+          <Stack spacing={3}>
+            <Box sx={{ textAlign: 'center' }}>
+              <Typography variant="h5" sx={{ fontWeight: 800, color: 'primary.main' }}>
+                家属注册
+              </Typography>
+              <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
+                智慧医养大数据公共服务平台
+              </Typography>
+            </Box>
 
-        <Form<RegisterFormValues>
-          form={form}
-          onFinish={handleSubmit}
-          size="large"
-          autoComplete="off"
-        >
-          <Form.Item
-            name="invite_code"
-            rules={[{ required: true, message: '请输入邀请码' }]}
-          >
-            <Input
-              prefix={<KeyOutlined />}
-              placeholder="请输入邀请码"
-              onChange={handleCodeChange}
-              onBlur={handleCodeBlur}
-            />
-          </Form.Item>
+            <Box component="form" onSubmit={handleSubmit} noValidate>
+              <Stack spacing={2.5}>
+                <TextField
+                  label="邀请码"
+                  value={values.invite_code}
+                  onChange={handleCodeChange}
+                  onBlur={handleCodeBlur}
+                  error={Boolean(errors.invite_code)}
+                  helperText={errors.invite_code || ' '}
+                  fullWidth
+                  InputProps={{
+                    startAdornment: (
+                      <InputAdornment position="start">
+                        <KeyRoundedIcon fontSize="small" />
+                      </InputAdornment>
+                    ),
+                  }}
+                />
 
-          {/* Invite code validation feedback */}
-          {(validating || codeValidation) && (
-            <div style={{ marginTop: -16, marginBottom: 16, fontSize: 13 }}>
-              {validating && (
-                <span style={{ color: '#8c8c8c' }}>验证中...</span>
-              )}
-              {!validating && codeValidation?.valid && (
-                <span style={{ color: '#52c41a' }}>
-                  关联老人：{codeValidation.elder_name}
-                </span>
-              )}
-              {!validating && codeValidation && !codeValidation.valid && (
-                <span style={{ color: '#ff4d4f' }}>邀请码无效</span>
-              )}
-            </div>
-          )}
+                {(validating || codeValidation) && (
+                  <Alert severity={validating ? 'info' : codeValidation?.valid ? 'success' : 'error'}>
+                    {validating
+                      ? '验证中...'
+                      : codeValidation?.valid
+                        ? `关联老人：${codeValidation.elder_name}`
+                        : '邀请码无效'}
+                  </Alert>
+                )}
 
-          <Form.Item
-            name="real_name"
-            rules={[{ required: true, message: '请输入姓名' }]}
-          >
-            <Input prefix={<UserOutlined />} placeholder="请输入姓名" />
-          </Form.Item>
+                <TextField
+                  label="姓名"
+                  value={values.real_name}
+                  onChange={(event) => updateField('real_name', event.target.value)}
+                  error={Boolean(errors.real_name)}
+                  helperText={errors.real_name || ' '}
+                  fullWidth
+                  InputProps={{
+                    startAdornment: (
+                      <InputAdornment position="start">
+                        <PersonOutlineRoundedIcon fontSize="small" />
+                      </InputAdornment>
+                    ),
+                  }}
+                />
 
-          <Form.Item
-            name="phone"
-            rules={[
-              { required: true, message: '请输入手机号' },
-              { pattern: /^1\d{10}$/, message: '请输入正确的手机号' },
-            ]}
-          >
-            <Input prefix={<PhoneOutlined />} placeholder="请输入手机号" />
-          </Form.Item>
+                <TextField
+                  label="手机号"
+                  value={values.phone}
+                  onChange={(event) => updateField('phone', event.target.value)}
+                  error={Boolean(errors.phone)}
+                  helperText={errors.phone || ' '}
+                  fullWidth
+                  InputProps={{
+                    startAdornment: (
+                      <InputAdornment position="start">
+                        <PhoneRoundedIcon fontSize="small" />
+                      </InputAdornment>
+                    ),
+                  }}
+                />
 
-          <Form.Item
-            name="password"
-            rules={[
-              { required: true, message: '请设置密码' },
-              { min: 6, message: '密码至少6位' },
-            ]}
-          >
-            <Input.Password prefix={<LockOutlined />} placeholder="请设置密码（至少6位）" />
-          </Form.Item>
+                <TextField
+                  label="密码"
+                  type="password"
+                  value={values.password}
+                  onChange={(event) => updateField('password', event.target.value)}
+                  error={Boolean(errors.password)}
+                  helperText={errors.password || ' '}
+                  fullWidth
+                  InputProps={{
+                    startAdornment: (
+                      <InputAdornment position="start">
+                        <LockOutlinedIcon fontSize="small" />
+                      </InputAdornment>
+                    ),
+                  }}
+                />
 
-          <Form.Item
-            name="confirm_password"
-            dependencies={['password']}
-            rules={[
-              { required: true, message: '请确认密码' },
-              ({ getFieldValue }) => ({
-                validator(_, value) {
-                  if (!value || getFieldValue('password') === value) {
-                    return Promise.resolve();
-                  }
-                  return Promise.reject(new Error('两次密码不一致'));
-                },
-              }),
-            ]}
-          >
-            <Input.Password prefix={<LockOutlined />} placeholder="请确认密码" />
-          </Form.Item>
+                <TextField
+                  label="确认密码"
+                  type="password"
+                  value={values.confirm_password}
+                  onChange={(event) => updateField('confirm_password', event.target.value)}
+                  error={Boolean(errors.confirm_password)}
+                  helperText={errors.confirm_password || ' '}
+                  fullWidth
+                  InputProps={{
+                    startAdornment: (
+                      <InputAdornment position="start">
+                        <LockOutlinedIcon fontSize="small" />
+                      </InputAdornment>
+                    ),
+                  }}
+                />
 
-          <Form.Item
-            name="relationship"
-            rules={[{ required: true, message: '请选择与老人的关系' }]}
-          >
-            <Select
-              placeholder="请选择与老人的关系"
-              options={relationshipOptions}
-              suffixIcon={<TeamOutlined />}
-            />
-          </Form.Item>
+                <FormControl fullWidth error={Boolean(errors.relationship)}>
+                  <InputLabel id="relationship-label">与老人关系</InputLabel>
+                  <Select
+                    labelId="relationship-label"
+                    label="与老人关系"
+                    value={values.relationship}
+                    onChange={(event) => updateField('relationship', String(event.target.value))}
+                    displayEmpty
+                    startAdornment={
+                      <InputAdornment position="start" sx={{ ml: 1, mr: 0 }}>
+                        <GroupsRoundedIcon fontSize="small" />
+                      </InputAdornment>
+                    }
+                  >
+                    <MenuItem value="">
+                      <em>请选择与老人的关系</em>
+                    </MenuItem>
+                    {relationshipOptions.map((option) => (
+                      <MenuItem key={option.value} value={option.value}>
+                        {option.label}
+                      </MenuItem>
+                    ))}
+                  </Select>
+                  <Typography variant="caption" color="error" sx={{ mt: 0.5, minHeight: 20 }}>
+                    {errors.relationship || ' '}
+                  </Typography>
+                </FormControl>
 
-          <Form.Item>
-            <Button type="primary" htmlType="submit" loading={loading} block>
-              注 册
-            </Button>
-          </Form.Item>
-        </Form>
+                <Button type="submit" variant="contained" size="large" fullWidth disabled={loading}>
+                  {loading ? '注册中...' : '注册'}
+                </Button>
+              </Stack>
+            </Box>
 
-        <div style={{ textAlign: 'center', marginTop: -8 }}>
-          <Button type="link" onClick={() => navigate('/login')}>
-            返回登录
-          </Button>
-        </div>
+            <Box sx={{ textAlign: 'center', mt: -0.5 }}>
+              <Button variant="text" onClick={() => navigate('/login')}>
+                返回登录
+              </Button>
+            </Box>
+          </Stack>
+        </CardContent>
       </Card>
 
       <SlideCaptcha
@@ -251,7 +382,7 @@ const FamilyRegisterPage: React.FC = () => {
         onSuccess={handleCaptchaSuccess}
         onCancel={handleCaptchaCancel}
       />
-    </>
+    </Box>
   );
 };
 

--- a/frontend/src/pages/family/FamilyRegisterPage.tsx
+++ b/frontend/src/pages/family/FamilyRegisterPage.tsx
@@ -1,16 +1,26 @@
-import React, { useState, useMemo, useEffect, useCallback } from 'react';
-import { Form, Input, Button, Card, Select, message } from 'antd';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import {
-  KeyOutlined,
-  UserOutlined,
-  PhoneOutlined,
-  LockOutlined,
-  TeamOutlined,
-} from '@ant-design/icons';
+  Alert,
+  Box,
+  Button,
+  Card,
+  CardContent,
+  InputAdornment,
+  MenuItem,
+  Stack,
+  TextField,
+  Typography,
+} from '@mui/material';
+import KeyRoundedIcon from '@mui/icons-material/KeyRounded';
+import PersonOutlineRoundedIcon from '@mui/icons-material/PersonOutlineRounded';
+import PhoneRoundedIcon from '@mui/icons-material/PhoneRounded';
+import LockOutlinedIcon from '@mui/icons-material/LockOutlined';
+import GroupsRoundedIcon from '@mui/icons-material/GroupsRounded';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import SlideCaptcha from '../../components/SlideCaptcha';
 import { validateInviteCode, registerFamily } from '../../api/family';
 import type { InviteCodeValidation } from '../../types/family';
+import { message } from '../../utils/message';
 
 interface RegisterFormValues {
   invite_code: string;
@@ -21,6 +31,8 @@ interface RegisterFormValues {
   relationship: string;
 }
 
+type RegisterFormErrors = Partial<Record<keyof RegisterFormValues, string>>;
+
 const relationshipOptions = [
   { value: '子女', label: '子女' },
   { value: '配偶', label: '配偶' },
@@ -28,19 +40,29 @@ const relationshipOptions = [
   { value: '其他', label: '其他' },
 ];
 
+const initialValues: RegisterFormValues = {
+  invite_code: '',
+  real_name: '',
+  phone: '',
+  password: '',
+  confirm_password: '',
+  relationship: '',
+};
+
 const FamilyRegisterPage: React.FC = () => {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
-  const [form] = Form.useForm<RegisterFormValues>();
   const [loading, setLoading] = useState(false);
   const [captchaVisible, setCaptchaVisible] = useState(false);
   const [codeValidation, setCodeValidation] = useState<InviteCodeValidation | null>(null);
   const [validating, setValidating] = useState(false);
+  const [values, setValues] = useState<RegisterFormValues>(initialValues);
+  const [errors, setErrors] = useState<RegisterFormErrors>({});
 
   const sessionId = useMemo(() => crypto.randomUUID(), []);
 
   const doValidateCode = useCallback(async (code: string) => {
-    if (!code || code.trim().length === 0) {
+    if (!code.trim()) {
       setCodeValidation(null);
       return;
     }
@@ -55,40 +77,120 @@ const FamilyRegisterPage: React.FC = () => {
     }
   }, []);
 
-  // Auto-fill and validate from URL query parameter
+  const ensureInviteCodeValid = useCallback(async (code: string) => {
+    setValidating(true);
+    try {
+      const res = await validateInviteCode(code);
+      const data = res.data as InviteCodeValidation;
+      setCodeValidation(data);
+      return data.valid;
+    } catch {
+      setCodeValidation({ valid: false, elder_name: '', remaining_slots: 0 });
+      return false;
+    } finally {
+      setValidating(false);
+    }
+  }, []);
+
+  const validateValues = useCallback((nextValues: RegisterFormValues) => {
+    const nextErrors: RegisterFormErrors = {};
+
+    if (!nextValues.invite_code.trim()) {
+      nextErrors.invite_code = '请输入邀请码';
+    }
+    if (!nextValues.real_name.trim()) {
+      nextErrors.real_name = '请输入姓名';
+    }
+    if (!nextValues.phone.trim()) {
+      nextErrors.phone = '请输入手机号';
+    } else if (!/^1\d{10}$/.test(nextValues.phone.trim())) {
+      nextErrors.phone = '请输入正确的手机号';
+    }
+    if (!nextValues.password) {
+      nextErrors.password = '请设置密码';
+    } else if (nextValues.password.length < 6) {
+      nextErrors.password = '密码至少6位';
+    }
+    if (!nextValues.confirm_password) {
+      nextErrors.confirm_password = '请确认密码';
+    } else if (nextValues.confirm_password !== nextValues.password) {
+      nextErrors.confirm_password = '两次密码不一致';
+    }
+    if (!nextValues.relationship) {
+      nextErrors.relationship = '请选择与老人的关系';
+    }
+
+    return nextErrors;
+  }, []);
+
+  const updateField = <K extends keyof RegisterFormValues>(key: K, value: RegisterFormValues[K]) => {
+    setValues((current) => {
+      const next = { ...current, [key]: value };
+      if (
+        key === 'password'
+        && current.confirm_password
+        && current.confirm_password !== value
+      ) {
+        setErrors((previous) => ({
+          ...previous,
+          confirm_password: '两次密码不一致',
+        }));
+      }
+      return next;
+    });
+    setErrors((current) => ({
+      ...current,
+      [key]: '',
+    }));
+  };
+
   useEffect(() => {
     const code = searchParams.get('code');
     if (code) {
-      form.setFieldsValue({ invite_code: code });
-      doValidateCode(code);
+      setValues((current) => ({
+        ...current,
+        invite_code: code,
+      }));
+      void doValidateCode(code);
     }
-  }, [searchParams, form, doValidateCode]);
+  }, [searchParams, doValidateCode]);
 
-  const handleCodeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const value = e.target.value;
-    if (value.length >= 8) {
-      doValidateCode(value);
+  const handleCodeChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const value = event.target.value;
+    updateField('invite_code', value);
+    if (value.trim().length >= 8) {
+      void doValidateCode(value);
     } else {
       setCodeValidation(null);
     }
   };
 
   const handleCodeBlur = () => {
-    const code = form.getFieldValue('invite_code') as string;
-    if (code && code.trim().length > 0) {
-      doValidateCode(code);
+    const code = values.invite_code;
+    if (code.trim()) {
+      void doValidateCode(code);
     }
   };
 
-  const handleSubmit = () => {
-    form.validateFields().then(() => {
-      setCaptchaVisible(true);
-    });
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const nextErrors = validateValues(values);
+    setErrors(nextErrors);
+    if (Object.keys(nextErrors).length > 0) {
+      return;
+    }
+
+    const isValid = await ensureInviteCodeValid(values.invite_code.trim());
+    if (!isValid) {
+      message.error('邀请码无效');
+      return;
+    }
+
+    setCaptchaVisible(true);
   };
 
   const handleCaptchaSuccess = async (captchaToken: string) => {
     setCaptchaVisible(false);
-    const values = form.getFieldsValue();
     setLoading(true);
     try {
       await registerFamily({
@@ -114,135 +216,159 @@ const FamilyRegisterPage: React.FC = () => {
   };
 
   return (
-    <>
+    <Box sx={{ width: '100%', maxWidth: 560 }}>
       <Card
-        style={{
-          width: 480,
-          borderRadius: 12,
-          boxShadow: '0 8px 32px rgba(0, 0, 0, 0.15)',
+        sx={{
+          overflow: 'hidden',
+          border: '1px solid',
+          borderColor: 'divider',
         }}
-        styles={{ body: { padding: '40px 32px' } }}
       >
-        <div style={{ textAlign: 'center', marginBottom: 32 }}>
-          <h1
-            style={{
-              fontSize: 22,
-              fontWeight: 700,
-              color: '#1677ff',
-              margin: 0,
-              lineHeight: 1.4,
-            }}
-          >
-            家属注册
-          </h1>
-          <p style={{ color: '#8c8c8c', fontSize: 14, margin: '8px 0 0' }}>
-            智慧医养大数据公共服务平台
-          </p>
-        </div>
+        <CardContent sx={{ p: { xs: 3, sm: 4 } }}>
+          <Stack spacing={3}>
+            <Box sx={{ textAlign: 'center' }}>
+              <Typography variant="h5" sx={{ fontWeight: 800, color: 'primary.main' }}>
+                家属注册
+              </Typography>
+              <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
+                智慧医养大数据公共服务平台
+              </Typography>
+            </Box>
 
-        <Form<RegisterFormValues>
-          form={form}
-          onFinish={handleSubmit}
-          size="large"
-          autoComplete="off"
-        >
-          <Form.Item
-            name="invite_code"
-            rules={[{ required: true, message: '请输入邀请码' }]}
-          >
-            <Input
-              prefix={<KeyOutlined />}
-              placeholder="请输入邀请码"
-              onChange={handleCodeChange}
-              onBlur={handleCodeBlur}
-            />
-          </Form.Item>
+            <Box component="form" onSubmit={handleSubmit} noValidate>
+              <Stack spacing={2.5}>
+                <TextField
+                  label="邀请码"
+                  value={values.invite_code}
+                  onChange={handleCodeChange}
+                  onBlur={handleCodeBlur}
+                  error={Boolean(errors.invite_code)}
+                  helperText={errors.invite_code || ' '}
+                  fullWidth
+                  InputProps={{
+                    startAdornment: (
+                      <InputAdornment position="start">
+                        <KeyRoundedIcon fontSize="small" />
+                      </InputAdornment>
+                    ),
+                  }}
+                />
 
-          {/* Invite code validation feedback */}
-          {(validating || codeValidation) && (
-            <div style={{ marginTop: -16, marginBottom: 16, fontSize: 13 }}>
-              {validating && (
-                <span style={{ color: '#8c8c8c' }}>验证中...</span>
-              )}
-              {!validating && codeValidation?.valid && (
-                <span style={{ color: '#52c41a' }}>
-                  关联老人：{codeValidation.elder_name}
-                </span>
-              )}
-              {!validating && codeValidation && !codeValidation.valid && (
-                <span style={{ color: '#ff4d4f' }}>邀请码无效</span>
-              )}
-            </div>
-          )}
+                {(validating || codeValidation) && (
+                  <Alert severity={validating ? 'info' : codeValidation?.valid ? 'success' : 'error'}>
+                    {validating
+                      ? '验证中...'
+                      : codeValidation?.valid
+                        ? `关联老人：${codeValidation.elder_name}`
+                        : '邀请码无效'}
+                  </Alert>
+                )}
 
-          <Form.Item
-            name="real_name"
-            rules={[{ required: true, message: '请输入姓名' }]}
-          >
-            <Input prefix={<UserOutlined />} placeholder="请输入姓名" />
-          </Form.Item>
+                <TextField
+                  label="姓名"
+                  value={values.real_name}
+                  onChange={(event) => updateField('real_name', event.target.value)}
+                  error={Boolean(errors.real_name)}
+                  helperText={errors.real_name || ' '}
+                  fullWidth
+                  InputProps={{
+                    startAdornment: (
+                      <InputAdornment position="start">
+                        <PersonOutlineRoundedIcon fontSize="small" />
+                      </InputAdornment>
+                    ),
+                  }}
+                />
 
-          <Form.Item
-            name="phone"
-            rules={[
-              { required: true, message: '请输入手机号' },
-              { pattern: /^1\d{10}$/, message: '请输入正确的手机号' },
-            ]}
-          >
-            <Input prefix={<PhoneOutlined />} placeholder="请输入手机号" />
-          </Form.Item>
+                <TextField
+                  label="手机号"
+                  value={values.phone}
+                  onChange={(event) => updateField('phone', event.target.value)}
+                  error={Boolean(errors.phone)}
+                  helperText={errors.phone || ' '}
+                  fullWidth
+                  InputProps={{
+                    startAdornment: (
+                      <InputAdornment position="start">
+                        <PhoneRoundedIcon fontSize="small" />
+                      </InputAdornment>
+                    ),
+                  }}
+                />
 
-          <Form.Item
-            name="password"
-            rules={[
-              { required: true, message: '请设置密码' },
-              { min: 6, message: '密码至少6位' },
-            ]}
-          >
-            <Input.Password prefix={<LockOutlined />} placeholder="请设置密码（至少6位）" />
-          </Form.Item>
+                <TextField
+                  label="密码"
+                  type="password"
+                  value={values.password}
+                  onChange={(event) => updateField('password', event.target.value)}
+                  error={Boolean(errors.password)}
+                  helperText={errors.password || ' '}
+                  fullWidth
+                  InputProps={{
+                    startAdornment: (
+                      <InputAdornment position="start">
+                        <LockOutlinedIcon fontSize="small" />
+                      </InputAdornment>
+                    ),
+                  }}
+                />
 
-          <Form.Item
-            name="confirm_password"
-            dependencies={['password']}
-            rules={[
-              { required: true, message: '请确认密码' },
-              ({ getFieldValue }) => ({
-                validator(_, value) {
-                  if (!value || getFieldValue('password') === value) {
-                    return Promise.resolve();
-                  }
-                  return Promise.reject(new Error('两次密码不一致'));
-                },
-              }),
-            ]}
-          >
-            <Input.Password prefix={<LockOutlined />} placeholder="请确认密码" />
-          </Form.Item>
+                <TextField
+                  label="确认密码"
+                  type="password"
+                  value={values.confirm_password}
+                  onChange={(event) => updateField('confirm_password', event.target.value)}
+                  error={Boolean(errors.confirm_password)}
+                  helperText={errors.confirm_password || ' '}
+                  fullWidth
+                  InputProps={{
+                    startAdornment: (
+                      <InputAdornment position="start">
+                        <LockOutlinedIcon fontSize="small" />
+                      </InputAdornment>
+                    ),
+                  }}
+                />
 
-          <Form.Item
-            name="relationship"
-            rules={[{ required: true, message: '请选择与老人的关系' }]}
-          >
-            <Select
-              placeholder="请选择与老人的关系"
-              options={relationshipOptions}
-              suffixIcon={<TeamOutlined />}
-            />
-          </Form.Item>
+                <TextField
+                  select
+                  label="与老人关系"
+                  value={values.relationship}
+                  onChange={(event) => updateField('relationship', String(event.target.value))}
+                  error={Boolean(errors.relationship)}
+                  helperText={errors.relationship || ' '}
+                  fullWidth
+                  InputProps={{
+                    startAdornment: (
+                      <InputAdornment position="start">
+                        <GroupsRoundedIcon fontSize="small" />
+                      </InputAdornment>
+                    ),
+                  }}
+                >
+                  <MenuItem value="">
+                    <em>请选择与老人的关系</em>
+                  </MenuItem>
+                  {relationshipOptions.map((option) => (
+                    <MenuItem key={option.value} value={option.value}>
+                      {option.label}
+                    </MenuItem>
+                  ))}
+                </TextField>
 
-          <Form.Item>
-            <Button type="primary" htmlType="submit" loading={loading} block>
-              注 册
-            </Button>
-          </Form.Item>
-        </Form>
+                <Button type="submit" variant="contained" size="large" fullWidth disabled={loading}>
+                  {loading ? '注册中...' : '注册'}
+                </Button>
+              </Stack>
+            </Box>
 
-        <div style={{ textAlign: 'center', marginTop: -8 }}>
-          <Button type="link" onClick={() => navigate('/login')}>
-            返回登录
-          </Button>
-        </div>
+            <Box sx={{ textAlign: 'center', mt: -0.5 }}>
+              <Button variant="text" onClick={() => navigate('/login')}>
+                返回登录
+              </Button>
+            </Box>
+          </Stack>
+        </CardContent>
       </Card>
 
       <SlideCaptcha
@@ -251,7 +377,7 @@ const FamilyRegisterPage: React.FC = () => {
         onSuccess={handleCaptchaSuccess}
         onCancel={handleCaptchaCancel}
       />
-    </>
+    </Box>
   );
 };
 

--- a/frontend/src/pages/followups/FollowupPlanPage.tsx
+++ b/frontend/src/pages/followups/FollowupPlanPage.tsx
@@ -1,7 +1,24 @@
 import React, { useState, useCallback } from 'react';
-import { Button, Tag, Space, Select, DatePicker, Popconfirm, message, Modal, Form, Input } from 'antd';
-import { PlusOutlined } from '@ant-design/icons';
-import type { ColumnsType } from 'antd/es/table';
+import {
+  Button,
+  Chip,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+  Stack,
+  TextField,
+} from '@mui/material';
+import AddRoundedIcon from '@mui/icons-material/AddRounded';
+import EditRoundedIcon from '@mui/icons-material/EditRounded';
+import PlayArrowRoundedIcon from '@mui/icons-material/PlayArrowRounded';
+import NoteAddRoundedIcon from '@mui/icons-material/NoteAddRounded';
+import DeleteRoundedIcon from '@mui/icons-material/DeleteRounded';
+import type { AppTableColumn } from '../../components/AppTable';
 import AppTable from '../../components/AppTable';
 import AppForm, { type FormFieldConfig } from '../../components/AppForm';
 import PermissionGuard from '../../components/PermissionGuard';
@@ -20,10 +37,8 @@ import {
   FOLLOWUP_TYPE_OPTIONS,
   FOLLOWUP_STATUS_COLORS,
 } from '../../utils/constants';
+import { message } from '../../utils/message';
 import type { Followup, FollowupListQuery } from '../../types/followup';
-
-const { RangePicker } = DatePicker;
-const { TextArea } = Input;
 
 const formFields: FormFieldConfig[] = [
   { name: 'elder_id', label: '老人ID', type: 'number', required: true },
@@ -39,7 +54,8 @@ const FollowupPlanPage: React.FC = () => {
   const [editingFollowup, setEditingFollowup] = useState<Followup | null>(null);
   const [recordModalVisible, setRecordModalVisible] = useState(false);
   const [recordFollowupId, setRecordFollowupId] = useState<number | null>(null);
-  const [recordForm] = Form.useForm();
+  const [recordResult, setRecordResult] = useState('');
+  const [recordNextAction, setRecordNextAction] = useState('');
 
   const fetchFn = useCallback(
     (params: FollowupListQuery & { page: number; page_size: number }) => getFollowups(params),
@@ -60,6 +76,10 @@ const FollowupPlanPage: React.FC = () => {
   };
 
   const handleDelete = async (id: number) => {
+    if (!window.confirm('确定删除该随访计划？')) {
+      return;
+    }
+
     try {
       await deleteFollowup(id);
       message.success('删除成功');
@@ -69,9 +89,13 @@ const FollowupPlanPage: React.FC = () => {
     }
   };
 
-  const handleStatusUpdate = async (id: number, status: string) => {
+  const handleStatusUpdate = async (id: number, status: Followup['status']) => {
+    if (!window.confirm(`确认将该随访标记为${formatFollowupStatus(status)}？`)) {
+      return;
+    }
+
     try {
-      await updateFollowupStatus(id, { status: status as Followup['status'] });
+      await updateFollowupStatus(id, { status });
       message.success('状态更新成功');
       refresh();
     } catch (err) {
@@ -81,30 +105,38 @@ const FollowupPlanPage: React.FC = () => {
 
   const handleAddRecord = (followupId: number) => {
     setRecordFollowupId(followupId);
+    setRecordResult('');
+    setRecordNextAction('');
     setRecordModalVisible(true);
   };
 
   const handleRecordSubmit = async () => {
+    if (!recordResult.trim()) {
+      message.warning('请输入随访结果');
+      return;
+    }
+
     try {
-      const values = await recordForm.validateFields();
       if (recordFollowupId) {
         await addFollowupRecord(recordFollowupId, {
           actual_time: new Date().toISOString(),
-          result: values.result,
-          next_action: values.next_action,
+          result: recordResult,
+          next_action: recordNextAction,
           status: 'completed',
         });
         message.success('记录添加成功');
         setRecordModalVisible(false);
-        recordForm.resetFields();
+        setRecordFollowupId(null);
+        setRecordResult('');
+        setRecordNextAction('');
         refresh();
       }
-    } catch {
-      // validation errors
+    } catch (err) {
+      message.error(err instanceof Error ? err.message : '记录失败');
     }
   };
 
-  const columns: ColumnsType<Followup> = [
+  const columns: AppTableColumn<Followup>[] = [
     { title: '老人ID', dataIndex: 'elder_id', width: 80 },
     { title: '老人姓名', dataIndex: 'elder_name', width: 100 },
     {
@@ -117,9 +149,21 @@ const FollowupPlanPage: React.FC = () => {
       title: '状态',
       dataIndex: 'status',
       width: 100,
-      render: (status: string) => (
-        <Tag color={FOLLOWUP_STATUS_COLORS[status]}>{formatFollowupStatus(status)}</Tag>
-      ),
+      render: (status: unknown) => {
+        const followupStatus = String(status ?? '');
+        return (
+          <Chip
+            size="small"
+            label={formatFollowupStatus(followupStatus)}
+            sx={{
+              color: FOLLOWUP_STATUS_COLORS[followupStatus] || 'text.primary',
+              borderColor: FOLLOWUP_STATUS_COLORS[followupStatus] || 'divider',
+              bgcolor: 'transparent',
+            }}
+            variant="outlined"
+          />
+        );
+      },
     },
     { title: '计划时间', dataIndex: 'planned_at', render: formatDateTime, width: 170 },
     { title: '负责人', dataIndex: 'assigned_to_name', width: 100 },
@@ -130,32 +174,47 @@ const FollowupPlanPage: React.FC = () => {
       width: 320,
       fixed: 'right',
       render: (_, record) => (
-        <Space>
+        <Stack direction="row" spacing={0.5} flexWrap="wrap">
           <PermissionGuard permission="followup:update">
-            <Button type="link" size="small" onClick={() => handleEdit(record)}>
+            <Button
+              size="small"
+              startIcon={<EditRoundedIcon />}
+              onClick={() => handleEdit(record)}
+            >
               编辑
             </Button>
             {record.status === 'todo' && (
               <Button
-                type="link"
                 size="small"
+                color="primary"
+                startIcon={<PlayArrowRoundedIcon />}
                 onClick={() => handleStatusUpdate(record.id, 'in_progress')}
               >
                 开始
               </Button>
             )}
             {record.status === 'in_progress' && (
-              <Button type="link" size="small" onClick={() => handleAddRecord(record.id)}>
+              <Button
+                size="small"
+                color="secondary"
+                startIcon={<NoteAddRoundedIcon />}
+                onClick={() => handleAddRecord(record.id)}
+              >
                 记录结果
               </Button>
             )}
           </PermissionGuard>
           <PermissionGuard permission="followup:update">
-            <Popconfirm title="确定删除？" onConfirm={() => handleDelete(record.id)}>
-              <Button type="link" size="small" danger>删除</Button>
-            </Popconfirm>
+            <Button
+              size="small"
+              color="inherit"
+              startIcon={<DeleteRoundedIcon />}
+              onClick={() => handleDelete(record.id)}
+            >
+              删除
+            </Button>
           </PermissionGuard>
-        </Space>
+        </Stack>
       ),
     },
   ];
@@ -171,38 +230,67 @@ const FollowupPlanPage: React.FC = () => {
         onSearch={handleSearch}
         searchPlaceholder="搜索随访计划"
         toolbar={
-          <Space wrap>
-            <Select
-              placeholder="状态"
-              allowClear
-              options={FOLLOWUP_STATUS_OPTIONS}
-              style={{ width: 120 }}
-              value={query.status || undefined}
-              onChange={(val) => setQuery((prev) => ({ ...prev, status: val }))}
+          <Stack direction={{ xs: 'column', md: 'row' }} spacing={1.5} flexWrap="wrap">
+            <FormControl size="small" sx={{ minWidth: 120 }}>
+              <InputLabel>状态</InputLabel>
+              <Select
+                label="状态"
+                value={query.status || ''}
+                onChange={(event) =>
+                  setQuery((prev) => ({ ...prev, status: event.target.value || undefined }))
+                }
+              >
+                <MenuItem value="">全部</MenuItem>
+                {FOLLOWUP_STATUS_OPTIONS.map((option) => (
+                  <MenuItem key={option.value} value={option.value}>
+                    {option.label}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+            <FormControl size="small" sx={{ minWidth: 120 }}>
+              <InputLabel>随访方式</InputLabel>
+              <Select
+                label="随访方式"
+                value={query.plan_type || ''}
+                onChange={(event) =>
+                  setQuery((prev) => ({ ...prev, plan_type: event.target.value || undefined }))
+                }
+              >
+                <MenuItem value="">全部</MenuItem>
+                {FOLLOWUP_TYPE_OPTIONS.map((option) => (
+                  <MenuItem key={option.value} value={option.value}>
+                    {option.label}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+            <TextField
+              label="开始日期"
+              type="date"
+              size="small"
+              value={query.date_start || ''}
+              onChange={(event) =>
+                setQuery((prev) => ({ ...prev, date_start: event.target.value || undefined }))
+              }
+              InputLabelProps={{ shrink: true }}
             />
-            <Select
-              placeholder="随访方式"
-              allowClear
-              options={FOLLOWUP_TYPE_OPTIONS}
-              style={{ width: 120 }}
-              value={query.plan_type || undefined}
-              onChange={(val) => setQuery((prev) => ({ ...prev, plan_type: val }))}
-            />
-            <RangePicker
-              onChange={(dates) => {
-                setQuery((prev) => ({
-                  ...prev,
-                  date_start: dates?.[0]?.format('YYYY-MM-DD') || undefined,
-                  date_end: dates?.[1]?.format('YYYY-MM-DD') || undefined,
-                }));
-              }}
+            <TextField
+              label="结束日期"
+              type="date"
+              size="small"
+              value={query.date_end || ''}
+              onChange={(event) =>
+                setQuery((prev) => ({ ...prev, date_end: event.target.value || undefined }))
+              }
+              InputLabelProps={{ shrink: true }}
             />
             <PermissionGuard permission="followup:create">
-              <Button type="primary" icon={<PlusOutlined />} onClick={handleCreate}>
+              <Button variant="contained" startIcon={<AddRoundedIcon />} onClick={handleCreate}>
                 新建随访计划
               </Button>
             </PermissionGuard>
-          </Space>
+          </Stack>
         }
       />
 
@@ -224,24 +312,52 @@ const FollowupPlanPage: React.FC = () => {
         onCancel={() => setFormVisible(false)}
       />
 
-      <Modal
-        title="记录随访结果"
+      <Dialog
         open={recordModalVisible}
-        onOk={handleRecordSubmit}
-        onCancel={() => {
+        onClose={() => {
           setRecordModalVisible(false);
-          recordForm.resetFields();
+          setRecordFollowupId(null);
         }}
+        fullWidth
+        maxWidth="sm"
       >
-        <Form form={recordForm} layout="vertical">
-          <Form.Item name="result" label="随访结果" rules={[{ required: true, message: '请输入随访结果' }]}>
-            <TextArea rows={3} placeholder="请输入随访结果" />
-          </Form.Item>
-          <Form.Item name="next_action" label="后续行动">
-            <TextArea rows={2} placeholder="请输入后续行动建议" />
-          </Form.Item>
-        </Form>
-      </Modal>
+        <DialogTitle>记录随访结果</DialogTitle>
+        <DialogContent>
+          <Stack spacing={2} sx={{ pt: 1 }}>
+            <TextField
+              label="随访结果"
+              value={recordResult}
+              onChange={(event) => setRecordResult(event.target.value)}
+              multiline
+              minRows={3}
+              fullWidth
+              required
+            />
+            <TextField
+              label="后续行动"
+              value={recordNextAction}
+              onChange={(event) => setRecordNextAction(event.target.value)}
+              multiline
+              minRows={2}
+              fullWidth
+            />
+          </Stack>
+        </DialogContent>
+        <DialogActions>
+          <Button
+            color="inherit"
+            onClick={() => {
+              setRecordModalVisible(false);
+              setRecordFollowupId(null);
+            }}
+          >
+            取消
+          </Button>
+          <Button variant="contained" onClick={handleRecordSubmit}>
+            保存
+          </Button>
+        </DialogActions>
+      </Dialog>
     </>
   );
 };

--- a/frontend/src/pages/followups/FollowupPlanPage.tsx
+++ b/frontend/src/pages/followups/FollowupPlanPage.tsx
@@ -1,7 +1,24 @@
 import React, { useState, useCallback } from 'react';
-import { Button, Tag, Space, Select, DatePicker, Popconfirm, message, Modal, Form, Input } from 'antd';
-import { PlusOutlined } from '@ant-design/icons';
-import type { ColumnsType } from 'antd/es/table';
+import {
+  Button,
+  Chip,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+  Stack,
+  TextField,
+} from '@mui/material';
+import AddRoundedIcon from '@mui/icons-material/AddRounded';
+import EditRoundedIcon from '@mui/icons-material/EditRounded';
+import PlayArrowRoundedIcon from '@mui/icons-material/PlayArrowRounded';
+import NoteAddRoundedIcon from '@mui/icons-material/NoteAddRounded';
+import DeleteRoundedIcon from '@mui/icons-material/DeleteRounded';
+import type { AppTableColumn } from '../../components/AppTable';
 import AppTable from '../../components/AppTable';
 import AppForm, { type FormFieldConfig } from '../../components/AppForm';
 import PermissionGuard from '../../components/PermissionGuard';
@@ -20,10 +37,8 @@ import {
   FOLLOWUP_TYPE_OPTIONS,
   FOLLOWUP_STATUS_COLORS,
 } from '../../utils/constants';
+import { message } from '../../utils/message';
 import type { Followup, FollowupListQuery } from '../../types/followup';
-
-const { RangePicker } = DatePicker;
-const { TextArea } = Input;
 
 const formFields: FormFieldConfig[] = [
   { name: 'elder_id', label: '老人ID', type: 'number', required: true },
@@ -39,7 +54,8 @@ const FollowupPlanPage: React.FC = () => {
   const [editingFollowup, setEditingFollowup] = useState<Followup | null>(null);
   const [recordModalVisible, setRecordModalVisible] = useState(false);
   const [recordFollowupId, setRecordFollowupId] = useState<number | null>(null);
-  const [recordForm] = Form.useForm();
+  const [recordResult, setRecordResult] = useState('');
+  const [recordNextAction, setRecordNextAction] = useState('');
 
   const fetchFn = useCallback(
     (params: FollowupListQuery & { page: number; page_size: number }) => getFollowups(params),
@@ -60,6 +76,10 @@ const FollowupPlanPage: React.FC = () => {
   };
 
   const handleDelete = async (id: number) => {
+    if (!window.confirm('确定删除该随访计划？')) {
+      return;
+    }
+
     try {
       await deleteFollowup(id);
       message.success('删除成功');
@@ -69,9 +89,13 @@ const FollowupPlanPage: React.FC = () => {
     }
   };
 
-  const handleStatusUpdate = async (id: number, status: string) => {
+  const handleStatusUpdate = async (id: number, status: Followup['status']) => {
+    if (!window.confirm(`确认将该随访标记为${formatFollowupStatus(status)}？`)) {
+      return;
+    }
+
     try {
-      await updateFollowupStatus(id, { status: status as Followup['status'] });
+      await updateFollowupStatus(id, { status });
       message.success('状态更新成功');
       refresh();
     } catch (err) {
@@ -81,47 +105,72 @@ const FollowupPlanPage: React.FC = () => {
 
   const handleAddRecord = (followupId: number) => {
     setRecordFollowupId(followupId);
+    setRecordResult('');
+    setRecordNextAction('');
     setRecordModalVisible(true);
   };
 
   const handleRecordSubmit = async () => {
+    if (!recordResult.trim()) {
+      message.warning('请输入随访结果');
+      return;
+    }
+
     try {
-      const values = await recordForm.validateFields();
       if (recordFollowupId) {
         await addFollowupRecord(recordFollowupId, {
           actual_time: new Date().toISOString(),
-          result: values.result,
-          next_action: values.next_action,
+          result: recordResult,
+          next_action: recordNextAction,
           status: 'completed',
         });
         message.success('记录添加成功');
         setRecordModalVisible(false);
-        recordForm.resetFields();
+        setRecordFollowupId(null);
+        setRecordResult('');
+        setRecordNextAction('');
         refresh();
       }
-    } catch {
-      // validation errors
+    } catch (err) {
+      message.error(err instanceof Error ? err.message : '记录失败');
     }
   };
 
-  const columns: ColumnsType<Followup> = [
+  const columns: AppTableColumn<Followup>[] = [
     { title: '老人ID', dataIndex: 'elder_id', width: 80 },
     { title: '老人姓名', dataIndex: 'elder_name', width: 100 },
     {
       title: '随访方式',
       dataIndex: 'plan_type',
       width: 100,
-      render: formatPlanType,
+      render: (value) => formatPlanType(value as string | null | undefined),
     },
     {
       title: '状态',
       dataIndex: 'status',
       width: 100,
-      render: (status: string) => (
-        <Tag color={FOLLOWUP_STATUS_COLORS[status]}>{formatFollowupStatus(status)}</Tag>
-      ),
+      render: (status: unknown) => {
+        const followupStatus = String(status ?? '');
+        return (
+          <Chip
+            size="small"
+            label={formatFollowupStatus(followupStatus)}
+            sx={{
+              color: FOLLOWUP_STATUS_COLORS[followupStatus] || 'text.primary',
+              borderColor: FOLLOWUP_STATUS_COLORS[followupStatus] || 'divider',
+              bgcolor: 'transparent',
+            }}
+            variant="outlined"
+          />
+        );
+      },
     },
-    { title: '计划时间', dataIndex: 'planned_at', render: formatDateTime, width: 170 },
+    {
+      title: '计划时间',
+      dataIndex: 'planned_at',
+      render: (value) => formatDateTime(value as string | null | undefined),
+      width: 170,
+    },
     { title: '负责人', dataIndex: 'assigned_to_name', width: 100 },
     { title: '备注', dataIndex: 'notes', ellipsis: true },
     {
@@ -130,32 +179,47 @@ const FollowupPlanPage: React.FC = () => {
       width: 320,
       fixed: 'right',
       render: (_, record) => (
-        <Space>
+        <Stack direction="row" spacing={0.5} flexWrap="wrap">
           <PermissionGuard permission="followup:update">
-            <Button type="link" size="small" onClick={() => handleEdit(record)}>
+            <Button
+              size="small"
+              startIcon={<EditRoundedIcon />}
+              onClick={() => handleEdit(record)}
+            >
               编辑
             </Button>
             {record.status === 'todo' && (
               <Button
-                type="link"
                 size="small"
+                color="primary"
+                startIcon={<PlayArrowRoundedIcon />}
                 onClick={() => handleStatusUpdate(record.id, 'in_progress')}
               >
                 开始
               </Button>
             )}
             {record.status === 'in_progress' && (
-              <Button type="link" size="small" onClick={() => handleAddRecord(record.id)}>
+              <Button
+                size="small"
+                color="secondary"
+                startIcon={<NoteAddRoundedIcon />}
+                onClick={() => handleAddRecord(record.id)}
+              >
                 记录结果
               </Button>
             )}
           </PermissionGuard>
           <PermissionGuard permission="followup:update">
-            <Popconfirm title="确定删除？" onConfirm={() => handleDelete(record.id)}>
-              <Button type="link" size="small" danger>删除</Button>
-            </Popconfirm>
+            <Button
+              size="small"
+              color="inherit"
+              startIcon={<DeleteRoundedIcon />}
+              onClick={() => handleDelete(record.id)}
+            >
+              删除
+            </Button>
           </PermissionGuard>
-        </Space>
+        </Stack>
       ),
     },
   ];
@@ -171,38 +235,67 @@ const FollowupPlanPage: React.FC = () => {
         onSearch={handleSearch}
         searchPlaceholder="搜索随访计划"
         toolbar={
-          <Space wrap>
-            <Select
-              placeholder="状态"
-              allowClear
-              options={FOLLOWUP_STATUS_OPTIONS}
-              style={{ width: 120 }}
-              value={query.status || undefined}
-              onChange={(val) => setQuery((prev) => ({ ...prev, status: val }))}
+          <Stack direction={{ xs: 'column', md: 'row' }} spacing={1.5} flexWrap="wrap">
+            <FormControl size="small" sx={{ minWidth: 120 }}>
+              <InputLabel>状态</InputLabel>
+              <Select
+                label="状态"
+                value={query.status || ''}
+                onChange={(event) =>
+                  setQuery((prev) => ({ ...prev, status: event.target.value || undefined }))
+                }
+              >
+                <MenuItem value="">全部</MenuItem>
+                {FOLLOWUP_STATUS_OPTIONS.map((option) => (
+                  <MenuItem key={option.value} value={option.value}>
+                    {option.label}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+            <FormControl size="small" sx={{ minWidth: 120 }}>
+              <InputLabel>随访方式</InputLabel>
+              <Select
+                label="随访方式"
+                value={query.plan_type || ''}
+                onChange={(event) =>
+                  setQuery((prev) => ({ ...prev, plan_type: event.target.value || undefined }))
+                }
+              >
+                <MenuItem value="">全部</MenuItem>
+                {FOLLOWUP_TYPE_OPTIONS.map((option) => (
+                  <MenuItem key={option.value} value={option.value}>
+                    {option.label}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+            <TextField
+              label="开始日期"
+              type="date"
+              size="small"
+              value={query.date_start || ''}
+              onChange={(event) =>
+                setQuery((prev) => ({ ...prev, date_start: event.target.value || undefined }))
+              }
+              InputLabelProps={{ shrink: true }}
             />
-            <Select
-              placeholder="随访方式"
-              allowClear
-              options={FOLLOWUP_TYPE_OPTIONS}
-              style={{ width: 120 }}
-              value={query.plan_type || undefined}
-              onChange={(val) => setQuery((prev) => ({ ...prev, plan_type: val }))}
-            />
-            <RangePicker
-              onChange={(dates) => {
-                setQuery((prev) => ({
-                  ...prev,
-                  date_start: dates?.[0]?.format('YYYY-MM-DD') || undefined,
-                  date_end: dates?.[1]?.format('YYYY-MM-DD') || undefined,
-                }));
-              }}
+            <TextField
+              label="结束日期"
+              type="date"
+              size="small"
+              value={query.date_end || ''}
+              onChange={(event) =>
+                setQuery((prev) => ({ ...prev, date_end: event.target.value || undefined }))
+              }
+              InputLabelProps={{ shrink: true }}
             />
             <PermissionGuard permission="followup:create">
-              <Button type="primary" icon={<PlusOutlined />} onClick={handleCreate}>
+              <Button variant="contained" startIcon={<AddRoundedIcon />} onClick={handleCreate}>
                 新建随访计划
               </Button>
             </PermissionGuard>
-          </Space>
+          </Stack>
         }
       />
 
@@ -224,24 +317,52 @@ const FollowupPlanPage: React.FC = () => {
         onCancel={() => setFormVisible(false)}
       />
 
-      <Modal
-        title="记录随访结果"
+      <Dialog
         open={recordModalVisible}
-        onOk={handleRecordSubmit}
-        onCancel={() => {
+        onClose={() => {
           setRecordModalVisible(false);
-          recordForm.resetFields();
+          setRecordFollowupId(null);
         }}
+        fullWidth
+        maxWidth="sm"
       >
-        <Form form={recordForm} layout="vertical">
-          <Form.Item name="result" label="随访结果" rules={[{ required: true, message: '请输入随访结果' }]}>
-            <TextArea rows={3} placeholder="请输入随访结果" />
-          </Form.Item>
-          <Form.Item name="next_action" label="后续行动">
-            <TextArea rows={2} placeholder="请输入后续行动建议" />
-          </Form.Item>
-        </Form>
-      </Modal>
+        <DialogTitle>记录随访结果</DialogTitle>
+        <DialogContent>
+          <Stack spacing={2} sx={{ pt: 1 }}>
+            <TextField
+              label="随访结果"
+              value={recordResult}
+              onChange={(event) => setRecordResult(event.target.value)}
+              multiline
+              minRows={3}
+              fullWidth
+              required
+            />
+            <TextField
+              label="后续行动"
+              value={recordNextAction}
+              onChange={(event) => setRecordNextAction(event.target.value)}
+              multiline
+              minRows={2}
+              fullWidth
+            />
+          </Stack>
+        </DialogContent>
+        <DialogActions>
+          <Button
+            color="inherit"
+            onClick={() => {
+              setRecordModalVisible(false);
+              setRecordFollowupId(null);
+            }}
+          >
+            取消
+          </Button>
+          <Button variant="contained" onClick={handleRecordSubmit}>
+            保存
+          </Button>
+        </DialogActions>
+      </Dialog>
     </>
   );
 };

--- a/frontend/src/pages/followups/FollowupRecordPage.tsx
+++ b/frontend/src/pages/followups/FollowupRecordPage.tsx
@@ -1,9 +1,11 @@
-import React, { useEffect, useState } from 'react';
-import { Card, Table, Tag, message } from 'antd';
-import type { ColumnsType } from 'antd/es/table';
+import React, { useCallback, useEffect, useState } from 'react';
+import { Chip } from '@mui/material';
+import type { AppTableColumn } from '../../components/AppTable';
+import AppTable from '../../components/AppTable';
 import { getFollowups } from '../../api/followups';
 import { formatDateTime, formatFollowupStatus, formatPlanType } from '../../utils/formatter';
 import { FOLLOWUP_STATUS_COLORS } from '../../utils/constants';
+import { message } from '../../utils/message';
 import type { Followup } from '../../types/followup';
 
 const FollowupRecordPage: React.FC = () => {
@@ -11,7 +13,7 @@ const FollowupRecordPage: React.FC = () => {
   const [loading, setLoading] = useState(false);
   const [pagination, setPagination] = useState({ current: 1, pageSize: 20, total: 0 });
 
-  const fetchData = async (page = 1, pageSize = 20) => {
+  const fetchData = useCallback(async (page = 1, pageSize = 20) => {
     setLoading(true);
     try {
       const res = await getFollowups({
@@ -26,51 +28,66 @@ const FollowupRecordPage: React.FC = () => {
     } finally {
       setLoading(false);
     }
-  };
+  }, []);
 
   useEffect(() => {
     fetchData();
-  }, []);
+  }, [fetchData]);
 
-  const columns: ColumnsType<Followup> = [
+  const columns: AppTableColumn<Followup>[] = [
     { title: '老人ID', dataIndex: 'elder_id', width: 80 },
     { title: '老人姓名', dataIndex: 'elder_name', width: 100 },
     {
       title: '随访方式',
       dataIndex: 'plan_type',
       width: 100,
-      render: formatPlanType,
+      render: (value) => formatPlanType(value as string | null | undefined),
     },
     {
       title: '状态',
       dataIndex: 'status',
       width: 100,
-      render: (status: string) => (
-        <Tag color={FOLLOWUP_STATUS_COLORS[status]}>{formatFollowupStatus(status)}</Tag>
-      ),
+      render: (status: unknown) => {
+        const followupStatus = String(status ?? '');
+        return (
+          <Chip
+            size="small"
+            label={formatFollowupStatus(followupStatus)}
+            sx={{
+              color: FOLLOWUP_STATUS_COLORS[followupStatus] || 'text.primary',
+              borderColor: FOLLOWUP_STATUS_COLORS[followupStatus] || 'divider',
+              bgcolor: 'transparent',
+            }}
+            variant="outlined"
+          />
+        );
+      },
     },
-    { title: '计划时间', dataIndex: 'planned_at', render: formatDateTime, width: 170 },
+    {
+      title: '计划时间',
+      dataIndex: 'planned_at',
+      render: (value) => formatDateTime(value as string | null | undefined),
+      width: 170,
+    },
     { title: '负责人', dataIndex: 'assigned_to_name', width: 100 },
     { title: '备注', dataIndex: 'notes', ellipsis: true },
-    { title: '创建时间', dataIndex: 'created_at', render: formatDateTime, width: 170 },
+    {
+      title: '创建时间',
+      dataIndex: 'created_at',
+      render: (value) => formatDateTime(value as string | null | undefined),
+      width: 170,
+    },
   ];
 
   return (
-    <Card title="随访记录">
-      <Table<Followup>
-        columns={columns}
-        dataSource={data}
-        loading={loading}
-        rowKey="id"
-        pagination={{
-          ...pagination,
-          showSizeChanger: true,
-          showTotal: (total) => `共 ${total} 条`,
-        }}
-        onChange={(pag) => fetchData(pag.current, pag.pageSize)}
-        scroll={{ x: 'max-content' }}
-      />
-    </Card>
+    <AppTable<Followup>
+      columns={columns}
+      dataSource={data}
+      loading={loading}
+      pagination={pagination}
+      onChange={(pag) => fetchData(pag.current, pag.pageSize)}
+      emptyText="暂无随访记录"
+    />
   );
 };
 

--- a/frontend/src/pages/followups/FollowupRecordPage.tsx
+++ b/frontend/src/pages/followups/FollowupRecordPage.tsx
@@ -1,9 +1,11 @@
-import React, { useEffect, useState } from 'react';
-import { Card, Table, Tag, message } from 'antd';
-import type { ColumnsType } from 'antd/es/table';
+import React, { useCallback, useEffect, useState } from 'react';
+import { Chip } from '@mui/material';
+import type { AppTableColumn } from '../../components/AppTable';
+import AppTable from '../../components/AppTable';
 import { getFollowups } from '../../api/followups';
 import { formatDateTime, formatFollowupStatus, formatPlanType } from '../../utils/formatter';
 import { FOLLOWUP_STATUS_COLORS } from '../../utils/constants';
+import { message } from '../../utils/message';
 import type { Followup } from '../../types/followup';
 
 const FollowupRecordPage: React.FC = () => {
@@ -11,7 +13,7 @@ const FollowupRecordPage: React.FC = () => {
   const [loading, setLoading] = useState(false);
   const [pagination, setPagination] = useState({ current: 1, pageSize: 20, total: 0 });
 
-  const fetchData = async (page = 1, pageSize = 20) => {
+  const fetchData = useCallback(async (page = 1, pageSize = 20) => {
     setLoading(true);
     try {
       const res = await getFollowups({
@@ -26,13 +28,13 @@ const FollowupRecordPage: React.FC = () => {
     } finally {
       setLoading(false);
     }
-  };
+  }, []);
 
   useEffect(() => {
     fetchData();
-  }, []);
+  }, [fetchData]);
 
-  const columns: ColumnsType<Followup> = [
+  const columns: AppTableColumn<Followup>[] = [
     { title: '老人ID', dataIndex: 'elder_id', width: 80 },
     { title: '老人姓名', dataIndex: 'elder_name', width: 100 },
     {
@@ -45,9 +47,21 @@ const FollowupRecordPage: React.FC = () => {
       title: '状态',
       dataIndex: 'status',
       width: 100,
-      render: (status: string) => (
-        <Tag color={FOLLOWUP_STATUS_COLORS[status]}>{formatFollowupStatus(status)}</Tag>
-      ),
+      render: (status: unknown) => {
+        const followupStatus = String(status ?? '');
+        return (
+          <Chip
+            size="small"
+            label={formatFollowupStatus(followupStatus)}
+            sx={{
+              color: FOLLOWUP_STATUS_COLORS[followupStatus] || 'text.primary',
+              borderColor: FOLLOWUP_STATUS_COLORS[followupStatus] || 'divider',
+              bgcolor: 'transparent',
+            }}
+            variant="outlined"
+          />
+        );
+      },
     },
     { title: '计划时间', dataIndex: 'planned_at', render: formatDateTime, width: 170 },
     { title: '负责人', dataIndex: 'assigned_to_name', width: 100 },
@@ -56,21 +70,14 @@ const FollowupRecordPage: React.FC = () => {
   ];
 
   return (
-    <Card title="随访记录">
-      <Table<Followup>
-        columns={columns}
-        dataSource={data}
-        loading={loading}
-        rowKey="id"
-        pagination={{
-          ...pagination,
-          showSizeChanger: true,
-          showTotal: (total) => `共 ${total} 条`,
-        }}
-        onChange={(pag) => fetchData(pag.current, pag.pageSize)}
-        scroll={{ x: 'max-content' }}
-      />
-    </Card>
+    <AppTable<Followup>
+      columns={columns}
+      dataSource={data}
+      loading={loading}
+      pagination={pagination}
+      onChange={(pag) => fetchData(pag.current, pag.pageSize)}
+      emptyText="暂无随访记录"
+    />
   );
 };
 

--- a/frontend/src/pages/interventions/InterventionPage.tsx
+++ b/frontend/src/pages/interventions/InterventionPage.tsx
@@ -1,7 +1,25 @@
 import React, { useState, useCallback } from 'react';
-import { Button, Tag, Space, Select, Popconfirm, Modal, Form, Input, message } from 'antd';
-import { PlusOutlined } from '@ant-design/icons';
-import type { ColumnsType } from 'antd/es/table';
+import {
+  Button,
+  Chip,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+  Stack,
+  TextField,
+} from '@mui/material';
+import AddRoundedIcon from '@mui/icons-material/AddRounded';
+import EditRoundedIcon from '@mui/icons-material/EditRounded';
+import PlayArrowRoundedIcon from '@mui/icons-material/PlayArrowRounded';
+import TaskAltRoundedIcon from '@mui/icons-material/TaskAltRounded';
+import StopRoundedIcon from '@mui/icons-material/StopRounded';
+import DeleteRoundedIcon from '@mui/icons-material/DeleteRounded';
+import type { AppTableColumn } from '../../components/AppTable';
 import AppTable from '../../components/AppTable';
 import AppForm, { type FormFieldConfig } from '../../components/AppForm';
 import PermissionGuard from '../../components/PermissionGuard';
@@ -15,9 +33,8 @@ import {
 } from '../../api/interventions';
 import { formatDateTime, formatInterventionStatus } from '../../utils/formatter';
 import { INTERVENTION_STATUS_OPTIONS, INTERVENTION_STATUS_COLORS } from '../../utils/constants';
+import { message } from '../../utils/message';
 import type { Intervention, InterventionListQuery } from '../../types/intervention';
-
-const { TextArea } = Input;
 
 const INTERVENTION_TYPE_OPTIONS = [
   { label: '用药指导', value: 'medication_guidance' },
@@ -39,8 +56,8 @@ const InterventionPage: React.FC = () => {
   const [formVisible, setFormVisible] = useState(false);
   const [editingItem, setEditingItem] = useState<Intervention | null>(null);
   const [statusModalVisible, setStatusModalVisible] = useState(false);
-  const [statusTarget, setStatusTarget] = useState<{ id: number; status: string } | null>(null);
-  const [statusForm] = Form.useForm();
+  const [statusTarget, setStatusTarget] = useState<{ id: number; status: Intervention['status'] } | null>(null);
+  const [statusResult, setStatusResult] = useState('');
 
   const fetchFn = useCallback(
     (params: InterventionListQuery & { page: number; page_size: number }) => getInterventions(params),
@@ -61,6 +78,10 @@ const InterventionPage: React.FC = () => {
   };
 
   const handleDelete = async (id: number) => {
+    if (!window.confirm('确定删除该干预记录？')) {
+      return;
+    }
+
     try {
       await deleteIntervention(id);
       message.success('删除成功');
@@ -70,30 +91,37 @@ const InterventionPage: React.FC = () => {
     }
   };
 
-  const openStatusModal = (id: number, status: string) => {
+  const openStatusModal = (id: number, status: Intervention['status']) => {
     setStatusTarget({ id, status });
+    setStatusResult('');
     setStatusModalVisible(true);
   };
 
   const handleStatusSubmit = async () => {
+    if (!statusTarget) {
+      return;
+    }
+
+    if (!window.confirm(`确认将该干预标记为${formatInterventionStatus(statusTarget.status)}？`)) {
+      return;
+    }
+
     try {
-      const values = await statusForm.validateFields();
-      if (statusTarget) {
-        await updateInterventionStatus(statusTarget.id, {
-          status: statusTarget.status as Intervention['status'],
-          result: values.result,
-        });
-        message.success('状态更新成功');
-        setStatusModalVisible(false);
-        statusForm.resetFields();
-        refresh();
-      }
-    } catch {
-      // validation errors
+      await updateInterventionStatus(statusTarget.id, {
+        status: statusTarget.status,
+        result: statusResult,
+      });
+      message.success('状态更新成功');
+      setStatusModalVisible(false);
+      setStatusTarget(null);
+      setStatusResult('');
+      refresh();
+    } catch (err) {
+      message.error(err instanceof Error ? err.message : '操作失败');
     }
   };
 
-  const columns: ColumnsType<Intervention> = [
+  const columns: AppTableColumn<Intervention>[] = [
     { title: '老人ID', dataIndex: 'elder_id', width: 80 },
     { title: '老人姓名', dataIndex: 'elder_name', width: 100 },
     { title: '干预类型', dataIndex: 'type', width: 120 },
@@ -101,29 +129,49 @@ const InterventionPage: React.FC = () => {
       title: '状态',
       dataIndex: 'status',
       width: 100,
-      render: (status: string) => (
-        <Tag color={INTERVENTION_STATUS_COLORS[status]}>
-          {formatInterventionStatus(status)}
-        </Tag>
-      ),
+      render: (status: unknown) => {
+        const interventionStatus = String(status ?? '');
+        return (
+          <Chip
+            size="small"
+            label={formatInterventionStatus(interventionStatus)}
+            sx={{
+              color: INTERVENTION_STATUS_COLORS[interventionStatus] || 'text.primary',
+              borderColor: INTERVENTION_STATUS_COLORS[interventionStatus] || 'divider',
+              bgcolor: 'transparent',
+            }}
+            variant="outlined"
+          />
+        );
+      },
     },
     { title: '干预内容', dataIndex: 'content', ellipsis: true },
-    { title: '执行时间', dataIndex: 'performed_at', render: formatDateTime, width: 170 },
+    {
+      title: '执行时间',
+      dataIndex: 'performed_at',
+      render: (value) => formatDateTime(value as string | null | undefined),
+      width: 170,
+    },
     {
       title: '操作',
       key: 'actions',
-      width: 300,
+      width: 320,
       fixed: 'right',
       render: (_, record) => (
-        <Space>
+        <Stack direction="row" spacing={0.5} flexWrap="wrap">
           <PermissionGuard permission="intervention:create">
-            <Button type="link" size="small" onClick={() => handleEdit(record)}>
+            <Button
+              size="small"
+              startIcon={<EditRoundedIcon />}
+              onClick={() => handleEdit(record)}
+            >
               编辑
             </Button>
             {record.status === 'planned' && (
               <Button
-                type="link"
                 size="small"
+                color="primary"
+                startIcon={<PlayArrowRoundedIcon />}
                 onClick={() => openStatusModal(record.id, 'ongoing')}
               >
                 开始执行
@@ -131,8 +179,9 @@ const InterventionPage: React.FC = () => {
             )}
             {record.status === 'ongoing' && (
               <Button
-                type="link"
                 size="small"
+                color="success"
+                startIcon={<TaskAltRoundedIcon />}
                 onClick={() => openStatusModal(record.id, 'completed')}
               >
                 完成
@@ -140,19 +189,24 @@ const InterventionPage: React.FC = () => {
             )}
             {(record.status === 'planned' || record.status === 'ongoing') && (
               <Button
-                type="link"
                 size="small"
-                danger
+                color="inherit"
+                startIcon={<StopRoundedIcon />}
                 onClick={() => openStatusModal(record.id, 'stopped')}
               >
                 停止
               </Button>
             )}
-            <Popconfirm title="确定删除？" onConfirm={() => handleDelete(record.id)}>
-              <Button type="link" size="small" danger>删除</Button>
-            </Popconfirm>
+            <Button
+              size="small"
+              color="inherit"
+              startIcon={<DeleteRoundedIcon />}
+              onClick={() => handleDelete(record.id)}
+            >
+              删除
+            </Button>
           </PermissionGuard>
-        </Space>
+        </Stack>
       ),
     },
   ];
@@ -168,29 +222,47 @@ const InterventionPage: React.FC = () => {
         onSearch={handleSearch}
         searchPlaceholder="搜索干预记录"
         toolbar={
-          <Space wrap>
-            <Select
-              placeholder="状态"
-              allowClear
-              options={INTERVENTION_STATUS_OPTIONS}
-              style={{ width: 120 }}
-              value={query.status || undefined}
-              onChange={(val) => setQuery((prev) => ({ ...prev, status: val }))}
-            />
-            <Select
-              placeholder="干预类型"
-              allowClear
-              options={INTERVENTION_TYPE_OPTIONS}
-              style={{ width: 120 }}
-              value={query.type || undefined}
-              onChange={(val) => setQuery((prev) => ({ ...prev, type: val }))}
-            />
+          <Stack direction={{ xs: 'column', md: 'row' }} spacing={1.5} flexWrap="wrap">
+            <FormControl size="small" sx={{ minWidth: 120 }}>
+              <InputLabel>状态</InputLabel>
+              <Select
+                label="状态"
+                value={query.status || ''}
+                onChange={(event) =>
+                  setQuery((prev) => ({ ...prev, status: event.target.value || undefined }))
+                }
+              >
+                <MenuItem value="">全部</MenuItem>
+                {INTERVENTION_STATUS_OPTIONS.map((option) => (
+                  <MenuItem key={option.value} value={option.value}>
+                    {option.label}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+            <FormControl size="small" sx={{ minWidth: 120 }}>
+              <InputLabel>干预类型</InputLabel>
+              <Select
+                label="干预类型"
+                value={query.type || ''}
+                onChange={(event) =>
+                  setQuery((prev) => ({ ...prev, type: event.target.value || undefined }))
+                }
+              >
+                <MenuItem value="">全部</MenuItem>
+                {INTERVENTION_TYPE_OPTIONS.map((option) => (
+                  <MenuItem key={option.value} value={option.value}>
+                    {option.label}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
             <PermissionGuard permission="intervention:create">
-              <Button type="primary" icon={<PlusOutlined />} onClick={handleCreate}>
+              <Button variant="contained" startIcon={<AddRoundedIcon />} onClick={handleCreate}>
                 新建干预
               </Button>
             </PermissionGuard>
-          </Space>
+          </Stack>
         }
       />
 
@@ -212,21 +284,43 @@ const InterventionPage: React.FC = () => {
         onCancel={() => setFormVisible(false)}
       />
 
-      <Modal
-        title="更新干预状态"
+      <Dialog
         open={statusModalVisible}
-        onOk={handleStatusSubmit}
-        onCancel={() => {
+        onClose={() => {
           setStatusModalVisible(false);
-          statusForm.resetFields();
+          setStatusTarget(null);
         }}
+        fullWidth
+        maxWidth="sm"
       >
-        <Form form={statusForm} layout="vertical">
-          <Form.Item name="result" label="执行结果">
-            <TextArea rows={3} placeholder="请输入执行结果（可选）" />
-          </Form.Item>
-        </Form>
-      </Modal>
+        <DialogTitle>更新干预状态</DialogTitle>
+        <DialogContent>
+          <Stack spacing={2} sx={{ pt: 1 }}>
+            <TextField
+              label="执行结果"
+              value={statusResult}
+              onChange={(event) => setStatusResult(event.target.value)}
+              multiline
+              minRows={3}
+              fullWidth
+            />
+          </Stack>
+        </DialogContent>
+        <DialogActions>
+          <Button
+            color="inherit"
+            onClick={() => {
+              setStatusModalVisible(false);
+              setStatusTarget(null);
+            }}
+          >
+            取消
+          </Button>
+          <Button variant="contained" onClick={handleStatusSubmit}>
+            保存
+          </Button>
+        </DialogActions>
+      </Dialog>
     </>
   );
 };

--- a/frontend/src/pages/interventions/InterventionPage.tsx
+++ b/frontend/src/pages/interventions/InterventionPage.tsx
@@ -1,7 +1,25 @@
 import React, { useState, useCallback } from 'react';
-import { Button, Tag, Space, Select, Popconfirm, Modal, Form, Input, message } from 'antd';
-import { PlusOutlined } from '@ant-design/icons';
-import type { ColumnsType } from 'antd/es/table';
+import {
+  Button,
+  Chip,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+  Stack,
+  TextField,
+} from '@mui/material';
+import AddRoundedIcon from '@mui/icons-material/AddRounded';
+import EditRoundedIcon from '@mui/icons-material/EditRounded';
+import PlayArrowRoundedIcon from '@mui/icons-material/PlayArrowRounded';
+import TaskAltRoundedIcon from '@mui/icons-material/TaskAltRounded';
+import StopRoundedIcon from '@mui/icons-material/StopRounded';
+import DeleteRoundedIcon from '@mui/icons-material/DeleteRounded';
+import type { AppTableColumn } from '../../components/AppTable';
 import AppTable from '../../components/AppTable';
 import AppForm, { type FormFieldConfig } from '../../components/AppForm';
 import PermissionGuard from '../../components/PermissionGuard';
@@ -15,9 +33,8 @@ import {
 } from '../../api/interventions';
 import { formatDateTime, formatInterventionStatus } from '../../utils/formatter';
 import { INTERVENTION_STATUS_OPTIONS, INTERVENTION_STATUS_COLORS } from '../../utils/constants';
+import { message } from '../../utils/message';
 import type { Intervention, InterventionListQuery } from '../../types/intervention';
-
-const { TextArea } = Input;
 
 const INTERVENTION_TYPE_OPTIONS = [
   { label: '用药指导', value: 'medication_guidance' },
@@ -39,8 +56,8 @@ const InterventionPage: React.FC = () => {
   const [formVisible, setFormVisible] = useState(false);
   const [editingItem, setEditingItem] = useState<Intervention | null>(null);
   const [statusModalVisible, setStatusModalVisible] = useState(false);
-  const [statusTarget, setStatusTarget] = useState<{ id: number; status: string } | null>(null);
-  const [statusForm] = Form.useForm();
+  const [statusTarget, setStatusTarget] = useState<{ id: number; status: Intervention['status'] } | null>(null);
+  const [statusResult, setStatusResult] = useState('');
 
   const fetchFn = useCallback(
     (params: InterventionListQuery & { page: number; page_size: number }) => getInterventions(params),
@@ -61,6 +78,10 @@ const InterventionPage: React.FC = () => {
   };
 
   const handleDelete = async (id: number) => {
+    if (!window.confirm('确定删除该干预记录？')) {
+      return;
+    }
+
     try {
       await deleteIntervention(id);
       message.success('删除成功');
@@ -70,30 +91,37 @@ const InterventionPage: React.FC = () => {
     }
   };
 
-  const openStatusModal = (id: number, status: string) => {
+  const openStatusModal = (id: number, status: Intervention['status']) => {
     setStatusTarget({ id, status });
+    setStatusResult('');
     setStatusModalVisible(true);
   };
 
   const handleStatusSubmit = async () => {
+    if (!statusTarget) {
+      return;
+    }
+
+    if (!window.confirm(`确认将该干预标记为${formatInterventionStatus(statusTarget.status)}？`)) {
+      return;
+    }
+
     try {
-      const values = await statusForm.validateFields();
-      if (statusTarget) {
-        await updateInterventionStatus(statusTarget.id, {
-          status: statusTarget.status as Intervention['status'],
-          result: values.result,
-        });
-        message.success('状态更新成功');
-        setStatusModalVisible(false);
-        statusForm.resetFields();
-        refresh();
-      }
-    } catch {
-      // validation errors
+      await updateInterventionStatus(statusTarget.id, {
+        status: statusTarget.status,
+        result: statusResult,
+      });
+      message.success('状态更新成功');
+      setStatusModalVisible(false);
+      setStatusTarget(null);
+      setStatusResult('');
+      refresh();
+    } catch (err) {
+      message.error(err instanceof Error ? err.message : '操作失败');
     }
   };
 
-  const columns: ColumnsType<Intervention> = [
+  const columns: AppTableColumn<Intervention>[] = [
     { title: '老人ID', dataIndex: 'elder_id', width: 80 },
     { title: '老人姓名', dataIndex: 'elder_name', width: 100 },
     { title: '干预类型', dataIndex: 'type', width: 120 },
@@ -101,29 +129,44 @@ const InterventionPage: React.FC = () => {
       title: '状态',
       dataIndex: 'status',
       width: 100,
-      render: (status: string) => (
-        <Tag color={INTERVENTION_STATUS_COLORS[status]}>
-          {formatInterventionStatus(status)}
-        </Tag>
-      ),
+      render: (status: unknown) => {
+        const interventionStatus = String(status ?? '');
+        return (
+          <Chip
+            size="small"
+            label={formatInterventionStatus(interventionStatus)}
+            sx={{
+              color: INTERVENTION_STATUS_COLORS[interventionStatus] || 'text.primary',
+              borderColor: INTERVENTION_STATUS_COLORS[interventionStatus] || 'divider',
+              bgcolor: 'transparent',
+            }}
+            variant="outlined"
+          />
+        );
+      },
     },
     { title: '干预内容', dataIndex: 'content', ellipsis: true },
     { title: '执行时间', dataIndex: 'performed_at', render: formatDateTime, width: 170 },
     {
       title: '操作',
       key: 'actions',
-      width: 300,
+      width: 320,
       fixed: 'right',
       render: (_, record) => (
-        <Space>
+        <Stack direction="row" spacing={0.5} flexWrap="wrap">
           <PermissionGuard permission="intervention:create">
-            <Button type="link" size="small" onClick={() => handleEdit(record)}>
+            <Button
+              size="small"
+              startIcon={<EditRoundedIcon />}
+              onClick={() => handleEdit(record)}
+            >
               编辑
             </Button>
             {record.status === 'planned' && (
               <Button
-                type="link"
                 size="small"
+                color="primary"
+                startIcon={<PlayArrowRoundedIcon />}
                 onClick={() => openStatusModal(record.id, 'ongoing')}
               >
                 开始执行
@@ -131,8 +174,9 @@ const InterventionPage: React.FC = () => {
             )}
             {record.status === 'ongoing' && (
               <Button
-                type="link"
                 size="small"
+                color="success"
+                startIcon={<TaskAltRoundedIcon />}
                 onClick={() => openStatusModal(record.id, 'completed')}
               >
                 完成
@@ -140,19 +184,24 @@ const InterventionPage: React.FC = () => {
             )}
             {(record.status === 'planned' || record.status === 'ongoing') && (
               <Button
-                type="link"
                 size="small"
-                danger
+                color="inherit"
+                startIcon={<StopRoundedIcon />}
                 onClick={() => openStatusModal(record.id, 'stopped')}
               >
                 停止
               </Button>
             )}
-            <Popconfirm title="确定删除？" onConfirm={() => handleDelete(record.id)}>
-              <Button type="link" size="small" danger>删除</Button>
-            </Popconfirm>
+            <Button
+              size="small"
+              color="inherit"
+              startIcon={<DeleteRoundedIcon />}
+              onClick={() => handleDelete(record.id)}
+            >
+              删除
+            </Button>
           </PermissionGuard>
-        </Space>
+        </Stack>
       ),
     },
   ];
@@ -168,29 +217,47 @@ const InterventionPage: React.FC = () => {
         onSearch={handleSearch}
         searchPlaceholder="搜索干预记录"
         toolbar={
-          <Space wrap>
-            <Select
-              placeholder="状态"
-              allowClear
-              options={INTERVENTION_STATUS_OPTIONS}
-              style={{ width: 120 }}
-              value={query.status || undefined}
-              onChange={(val) => setQuery((prev) => ({ ...prev, status: val }))}
-            />
-            <Select
-              placeholder="干预类型"
-              allowClear
-              options={INTERVENTION_TYPE_OPTIONS}
-              style={{ width: 120 }}
-              value={query.type || undefined}
-              onChange={(val) => setQuery((prev) => ({ ...prev, type: val }))}
-            />
+          <Stack direction={{ xs: 'column', md: 'row' }} spacing={1.5} flexWrap="wrap">
+            <FormControl size="small" sx={{ minWidth: 120 }}>
+              <InputLabel>状态</InputLabel>
+              <Select
+                label="状态"
+                value={query.status || ''}
+                onChange={(event) =>
+                  setQuery((prev) => ({ ...prev, status: event.target.value || undefined }))
+                }
+              >
+                <MenuItem value="">全部</MenuItem>
+                {INTERVENTION_STATUS_OPTIONS.map((option) => (
+                  <MenuItem key={option.value} value={option.value}>
+                    {option.label}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+            <FormControl size="small" sx={{ minWidth: 120 }}>
+              <InputLabel>干预类型</InputLabel>
+              <Select
+                label="干预类型"
+                value={query.type || ''}
+                onChange={(event) =>
+                  setQuery((prev) => ({ ...prev, type: event.target.value || undefined }))
+                }
+              >
+                <MenuItem value="">全部</MenuItem>
+                {INTERVENTION_TYPE_OPTIONS.map((option) => (
+                  <MenuItem key={option.value} value={option.value}>
+                    {option.label}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
             <PermissionGuard permission="intervention:create">
-              <Button type="primary" icon={<PlusOutlined />} onClick={handleCreate}>
+              <Button variant="contained" startIcon={<AddRoundedIcon />} onClick={handleCreate}>
                 新建干预
               </Button>
             </PermissionGuard>
-          </Space>
+          </Stack>
         }
       />
 
@@ -212,21 +279,43 @@ const InterventionPage: React.FC = () => {
         onCancel={() => setFormVisible(false)}
       />
 
-      <Modal
-        title="更新干预状态"
+      <Dialog
         open={statusModalVisible}
-        onOk={handleStatusSubmit}
-        onCancel={() => {
+        onClose={() => {
           setStatusModalVisible(false);
-          statusForm.resetFields();
+          setStatusTarget(null);
         }}
+        fullWidth
+        maxWidth="sm"
       >
-        <Form form={statusForm} layout="vertical">
-          <Form.Item name="result" label="执行结果">
-            <TextArea rows={3} placeholder="请输入执行结果（可选）" />
-          </Form.Item>
-        </Form>
-      </Modal>
+        <DialogTitle>更新干预状态</DialogTitle>
+        <DialogContent>
+          <Stack spacing={2} sx={{ pt: 1 }}>
+            <TextField
+              label="执行结果"
+              value={statusResult}
+              onChange={(event) => setStatusResult(event.target.value)}
+              multiline
+              minRows={3}
+              fullWidth
+            />
+          </Stack>
+        </DialogContent>
+        <DialogActions>
+          <Button
+            color="inherit"
+            onClick={() => {
+              setStatusModalVisible(false);
+              setStatusTarget(null);
+            }}
+          >
+            取消
+          </Button>
+          <Button variant="contained" onClick={handleStatusSubmit}>
+            保存
+          </Button>
+        </DialogActions>
+      </Dialog>
     </>
   );
 };

--- a/frontend/src/pages/login/LoginPage.tsx
+++ b/frontend/src/pages/login/LoginPage.tsx
@@ -1,33 +1,73 @@
-import React, { useState, useMemo } from 'react';
-import { Form, Input, Button, Card, message } from 'antd';
-import { UserOutlined, LockOutlined } from '@ant-design/icons';
+import React, { useMemo, useState } from 'react';
+import {
+  Box,
+  Button,
+  Card,
+  CardContent,
+  InputAdornment,
+  Stack,
+  TextField,
+  Typography,
+} from '@mui/material';
+import PersonOutlineRoundedIcon from '@mui/icons-material/PersonOutlineRounded';
+import LockOutlinedIcon from '@mui/icons-material/LockOutlined';
 import { useNavigate } from 'react-router-dom';
 import { useAuthStore, getHomeRoute } from '../../store/auth';
 import SlideCaptcha from '../../components/SlideCaptcha';
+import { message } from '../../utils/message';
 
 interface LoginFormValues {
   username: string;
   password: string;
 }
 
+type LoginFormErrors = Partial<Record<keyof LoginFormValues, string>>;
+
+function validateLoginForm(values: LoginFormValues): LoginFormErrors {
+  const errors: LoginFormErrors = {};
+
+  if (!values.username.trim()) {
+    errors.username = '请输入用户名';
+  }
+  if (!values.password.trim()) {
+    errors.password = '请输入密码';
+  }
+
+  return errors;
+}
+
 const LoginPage: React.FC = () => {
   const navigate = useNavigate();
   const login = useAuthStore((state) => state.login);
-  const [form] = Form.useForm<LoginFormValues>();
   const [loading, setLoading] = useState(false);
   const [captchaVisible, setCaptchaVisible] = useState(false);
+  const [values, setValues] = useState<LoginFormValues>({ username: '', password: '' });
+  const [errors, setErrors] = useState<LoginFormErrors>({});
 
   const sessionId = useMemo(() => crypto.randomUUID(), []);
 
-  const handleSubmit = () => {
-    form.validateFields().then(() => {
+  const updateField = <K extends keyof LoginFormValues>(key: K, value: LoginFormValues[K]) => {
+    setValues((current) => ({
+      ...current,
+      [key]: value,
+    }));
+    setErrors((current) => ({
+      ...current,
+      [key]: '',
+    }));
+  };
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const nextErrors = validateLoginForm(values);
+    setErrors(nextErrors);
+    if (Object.keys(nextErrors).length === 0) {
       setCaptchaVisible(true);
-    });
+    }
   };
 
   const handleCaptchaSuccess = async (captchaToken: string) => {
     setCaptchaVisible(false);
-    const values = form.getFieldsValue();
     setLoading(true);
     try {
       await login({
@@ -52,58 +92,75 @@ const LoginPage: React.FC = () => {
   };
 
   return (
-    <>
+    <Box sx={{ width: '100%', maxWidth: 480 }}>
       <Card
-        style={{
-          width: 420,
-          borderRadius: 12,
-          boxShadow: '0 8px 32px rgba(0, 0, 0, 0.15)',
+        sx={{
+          overflow: 'hidden',
+          border: '1px solid',
+          borderColor: 'divider',
         }}
-        styles={{ body: { padding: '40px 32px' } }}
       >
-        <div style={{ textAlign: 'center', marginBottom: 32 }}>
-          <h1
-            style={{
-              fontSize: 22,
-              fontWeight: 700,
-              color: '#1677ff',
-              margin: 0,
-              lineHeight: 1.4,
-            }}
-          >
-            智慧医养大数据公共服务平台
-          </h1>
-          <p style={{ color: '#8c8c8c', fontSize: 14, margin: '8px 0 0' }}>
-            医生服务系统
-          </p>
-        </div>
+        <CardContent sx={{ p: { xs: 3, sm: 4 } }}>
+          <Stack spacing={3}>
+            <Box sx={{ textAlign: 'center' }}>
+              <Typography variant="h5" sx={{ fontWeight: 800, color: 'primary.main' }}>
+                智慧医养大数据公共服务平台
+              </Typography>
+              <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
+                医生服务系统
+              </Typography>
+            </Box>
 
-        <Form<LoginFormValues>
-          form={form}
-          onFinish={handleSubmit}
-          size="large"
-          autoComplete="off"
-        >
-          <Form.Item name="username" rules={[{ required: true, message: '请输入用户名' }]}>
-            <Input prefix={<UserOutlined />} placeholder="用户名" />
-          </Form.Item>
+            <Box component="form" onSubmit={handleSubmit} noValidate>
+              <Stack spacing={2.5}>
+                <TextField
+                  label="用户名"
+                  value={values.username}
+                  onChange={(event) => updateField('username', event.target.value)}
+                  error={Boolean(errors.username)}
+                  helperText={errors.username || ' '}
+                  autoComplete="username"
+                  fullWidth
+                  InputProps={{
+                    startAdornment: (
+                      <InputAdornment position="start">
+                        <PersonOutlineRoundedIcon fontSize="small" />
+                      </InputAdornment>
+                    ),
+                  }}
+                />
 
-          <Form.Item name="password" rules={[{ required: true, message: '请输入密码' }]}>
-            <Input.Password prefix={<LockOutlined />} placeholder="密码" />
-          </Form.Item>
+                <TextField
+                  label="密码"
+                  type="password"
+                  value={values.password}
+                  onChange={(event) => updateField('password', event.target.value)}
+                  error={Boolean(errors.password)}
+                  helperText={errors.password || ' '}
+                  autoComplete="current-password"
+                  fullWidth
+                  InputProps={{
+                    startAdornment: (
+                      <InputAdornment position="start">
+                        <LockOutlinedIcon fontSize="small" />
+                      </InputAdornment>
+                    ),
+                  }}
+                />
 
-          <Form.Item>
-            <Button type="primary" htmlType="submit" loading={loading} block>
-              登 录
-            </Button>
-          </Form.Item>
-        </Form>
+                <Button type="submit" variant="contained" size="large" fullWidth disabled={loading}>
+                  {loading ? '登录中...' : '登录'}
+                </Button>
+              </Stack>
+            </Box>
 
-        <div style={{ textAlign: 'center', marginTop: -8 }}>
-          <Button type="link" onClick={() => navigate('/register/family')}>
-            家属注册
-          </Button>
-        </div>
+            <Box sx={{ textAlign: 'center', mt: -0.5 }}>
+              <Button variant="text" onClick={() => navigate('/register/family')}>
+                家属注册
+              </Button>
+            </Box>
+          </Stack>
+        </CardContent>
       </Card>
 
       <SlideCaptcha
@@ -112,7 +169,7 @@ const LoginPage: React.FC = () => {
         onSuccess={handleCaptchaSuccess}
         onCancel={handleCaptchaCancel}
       />
-    </>
+    </Box>
   );
 };
 

--- a/frontend/src/pages/system/RolePage.tsx
+++ b/frontend/src/pages/system/RolePage.tsx
@@ -1,12 +1,25 @@
-import React, { useState, useEffect, useCallback } from 'react';
-import { Button, Space, Modal, Tree, Table, message } from 'antd';
-import { PlusOutlined, SettingOutlined } from '@ant-design/icons';
-import type { ColumnsType } from 'antd/es/table';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  Box,
+  Button,
+  Checkbox,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControlLabel,
+  Stack,
+  Typography,
+} from '@mui/material';
+import AddRoundedIcon from '@mui/icons-material/AddRounded';
+import ManageAccountsRoundedIcon from '@mui/icons-material/ManageAccountsRounded';
+import AppTable, { type AppTableColumn } from '../../components/AppTable';
 import AppForm, { type FormFieldConfig } from '../../components/AppForm';
 import PermissionGuard from '../../components/PermissionGuard';
 import { getRoles, createRole, updateRolePermissions, getPermissionsTree } from '../../api/system';
 import { formatDateTime } from '../../utils/formatter';
-import type { Role, PermissionNode } from '../../types/user';
+import type { PermissionNode, Role } from '../../types/user';
+import { message } from '../../utils/message';
 
 const formFields: FormFieldConfig[] = [
   { name: 'name', label: '角色标识', required: true, placeholder: '如 doctor, admin' },
@@ -14,17 +27,71 @@ const formFields: FormFieldConfig[] = [
   { name: 'description', label: '描述', type: 'textarea' },
 ];
 
+function collectNodeKeys(node: PermissionNode): string[] {
+  return [node.key, ...(node.children?.flatMap(collectNodeKeys) ?? [])];
+}
+
+function PermissionTreeNode({
+  node,
+  depth,
+  selectedKeys,
+  onToggle,
+}: {
+  node: PermissionNode;
+  depth: number;
+  selectedKeys: Set<string>;
+  onToggle: (node: PermissionNode, checked: boolean) => void;
+}) {
+  const nodeKeys = useMemo(() => collectNodeKeys(node), [node]);
+  const selectedCount = nodeKeys.filter((key) => selectedKeys.has(key)).length;
+  const checked = selectedCount === nodeKeys.length;
+  const indeterminate = selectedCount > 0 && selectedCount < nodeKeys.length;
+
+  return (
+    <Box sx={{ pl: depth * 2 }}>
+      <FormControlLabel
+        control={
+          <Checkbox
+            checked={checked}
+            indeterminate={indeterminate}
+            onChange={(_, nextChecked) => onToggle(node, nextChecked)}
+          />
+        }
+        label={
+          <Typography variant="body2" sx={{ fontWeight: depth === 0 ? 600 : 400 }}>
+            {node.title}
+          </Typography>
+        }
+        sx={{ alignItems: 'flex-start', mr: 0 }}
+      />
+      <Stack spacing={0.25}>
+        {node.children?.map((child) => (
+          <PermissionTreeNode
+            key={child.key}
+            node={child}
+            depth={depth + 1}
+            selectedKeys={selectedKeys}
+            onToggle={onToggle}
+          />
+        ))}
+      </Stack>
+    </Box>
+  );
+}
+
 const RolePage: React.FC = () => {
   const [roles, setRoles] = useState<Role[]>([]);
   const [loading, setLoading] = useState(false);
   const [formVisible, setFormVisible] = useState(false);
+  const [submitLoading, setSubmitLoading] = useState(false);
 
-  // Permission assignment
   const [permModalVisible, setPermModalVisible] = useState(false);
   const [permissionsTree, setPermissionsTree] = useState<PermissionNode[]>([]);
-  const [checkedKeys, setCheckedKeys] = useState<React.Key[]>([]);
+  const [checkedKeys, setCheckedKeys] = useState<string[]>([]);
   const [currentRole, setCurrentRole] = useState<Role | null>(null);
   const [permLoading, setPermLoading] = useState(false);
+
+  const checkedKeySet = useMemo(() => new Set(checkedKeys), [checkedKeys]);
 
   const fetchRoles = useCallback(async () => {
     setLoading(true);
@@ -49,16 +116,31 @@ const RolePage: React.FC = () => {
       const res = await getPermissionsTree();
       setPermissionsTree(res.data);
     } catch {
-      // silent
+      setPermissionsTree([]);
     }
     setPermModalVisible(true);
+  };
+
+  const handlePermToggle = (node: PermissionNode, checked: boolean) => {
+    const nodeKeys = collectNodeKeys(node);
+    setCheckedKeys((previous) => {
+      const next = new Set(previous);
+      nodeKeys.forEach((key) => {
+        if (checked) {
+          next.add(key);
+        } else {
+          next.delete(key);
+        }
+      });
+      return Array.from(next);
+    });
   };
 
   const handlePermSubmit = async () => {
     if (!currentRole) return;
     setPermLoading(true);
     try {
-      await updateRolePermissions(currentRole.id, checkedKeys as string[]);
+      await updateRolePermissions(currentRole.id, checkedKeys);
       message.success('权限更新成功');
       setPermModalVisible(false);
       fetchRoles();
@@ -69,7 +151,7 @@ const RolePage: React.FC = () => {
     }
   };
 
-  const columns: ColumnsType<Role> = [
+  const columns: AppTableColumn<Role>[] = [
     { title: '角色标识', dataIndex: 'name', width: 150 },
     { title: '角色名称', dataIndex: 'display_name', width: 150 },
     { title: '描述', dataIndex: 'description', ellipsis: true },
@@ -79,76 +161,89 @@ const RolePage: React.FC = () => {
       key: 'actions',
       width: 150,
       render: (_, record) => (
-        <Space>
-          <PermissionGuard permission="role:manage">
-            <Button
-              type="link"
-              size="small"
-              icon={<SettingOutlined />}
-              onClick={() => openPermModal(record)}
-            >
-              配置权限
-            </Button>
-          </PermissionGuard>
-        </Space>
+        <PermissionGuard permission="role:manage">
+          <Button
+            size="small"
+            variant="text"
+            startIcon={<ManageAccountsRoundedIcon fontSize="small" />}
+            onClick={() => openPermModal(record)}
+          >
+            配置权限
+          </Button>
+        </PermissionGuard>
       ),
     },
   ];
 
   return (
     <>
-      <div style={{ marginBottom: 16, display: 'flex', justifyContent: 'flex-end' }}>
-        <PermissionGuard permission="role:manage">
-          <Button type="primary" icon={<PlusOutlined />} onClick={() => setFormVisible(true)}>
-            新增角色
-          </Button>
-        </PermissionGuard>
-      </div>
-
-      <Table<Role>
+      <AppTable<Role>
         columns={columns}
         dataSource={roles}
         loading={loading}
-        rowKey="id"
         pagination={false}
+        toolbar={
+          <PermissionGuard permission="role:manage">
+            <Button variant="contained" startIcon={<AddRoundedIcon />} onClick={() => setFormVisible(true)}>
+              新增角色
+            </Button>
+          </PermissionGuard>
+        }
       />
 
       <AppForm
         title="新增角色"
         visible={formVisible}
         fields={formFields}
+        confirmLoading={submitLoading}
         onSubmit={async (values) => {
-          await createRole(values as Parameters<typeof createRole>[0]);
-          message.success('创建成功');
-          setFormVisible(false);
-          fetchRoles();
+          setSubmitLoading(true);
+          try {
+            await createRole(values as Parameters<typeof createRole>[0]);
+            message.success('创建成功');
+            setFormVisible(false);
+            fetchRoles();
+          } finally {
+            setSubmitLoading(false);
+          }
         }}
         onCancel={() => setFormVisible(false)}
       />
 
-      <Modal
-        title={`配置权限 - ${currentRole?.display_name || ''}`}
+      <Dialog
         open={permModalVisible}
-        onOk={handlePermSubmit}
-        onCancel={() => setPermModalVisible(false)}
-        confirmLoading={permLoading}
-        width={480}
+        onClose={() => setPermModalVisible(false)}
+        maxWidth="sm"
+        fullWidth
       >
-        <Tree
-          checkable
-          checkedKeys={checkedKeys}
-          onCheck={(keys) => setCheckedKeys(keys as React.Key[])}
-          treeData={permissionsTree.map((node) => ({
-            key: node.key,
-            title: node.title,
-            children: node.children?.map((child) => ({
-              key: child.key,
-              title: child.title,
-            })),
-          }))}
-          defaultExpandAll
-        />
-      </Modal>
+        <DialogTitle>{`配置权限 - ${currentRole?.display_name || ''}`}</DialogTitle>
+        <DialogContent dividers>
+          <Stack spacing={1.5} sx={{ pt: 1 }}>
+            <Typography variant="body2" color="text.secondary">
+              勾选权限后将覆盖该角色现有权限。
+            </Typography>
+            <Stack spacing={0.5}>
+              {permissionsTree.map((node) => (
+                <PermissionTreeNode
+                  key={node.key}
+                  node={node}
+                  depth={0}
+                  selectedKeys={checkedKeySet}
+                  onToggle={handlePermToggle}
+                />
+              ))}
+            </Stack>
+          </Stack>
+        </DialogContent>
+        <DialogActions sx={{ px: 3, py: 2 }}>
+          <Button onClick={() => setPermModalVisible(false)} color="inherit">
+            取消
+          </Button>
+          <Button onClick={handlePermSubmit} variant="contained" disabled={permLoading}>
+            {permLoading ? '保存中...' : '确定'}
+          </Button>
+        </DialogActions>
+      </Dialog>
     </>
   );
 };

--- a/frontend/src/pages/system/RolePage.tsx
+++ b/frontend/src/pages/system/RolePage.tsx
@@ -1,12 +1,25 @@
-import React, { useState, useEffect, useCallback } from 'react';
-import { Button, Space, Modal, Tree, Table, message } from 'antd';
-import { PlusOutlined, SettingOutlined } from '@ant-design/icons';
-import type { ColumnsType } from 'antd/es/table';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  Box,
+  Button,
+  Checkbox,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControlLabel,
+  Stack,
+  Typography,
+} from '@mui/material';
+import AddRoundedIcon from '@mui/icons-material/AddRounded';
+import ManageAccountsRoundedIcon from '@mui/icons-material/ManageAccountsRounded';
+import AppTable, { type AppTableColumn } from '../../components/AppTable';
 import AppForm, { type FormFieldConfig } from '../../components/AppForm';
 import PermissionGuard from '../../components/PermissionGuard';
 import { getRoles, createRole, updateRolePermissions, getPermissionsTree } from '../../api/system';
 import { formatDateTime } from '../../utils/formatter';
-import type { Role, PermissionNode } from '../../types/user';
+import type { PermissionNode, Role } from '../../types/user';
+import { message } from '../../utils/message';
 
 const formFields: FormFieldConfig[] = [
   { name: 'name', label: '角色标识', required: true, placeholder: '如 doctor, admin' },
@@ -14,17 +27,71 @@ const formFields: FormFieldConfig[] = [
   { name: 'description', label: '描述', type: 'textarea' },
 ];
 
+function collectNodeKeys(node: PermissionNode): string[] {
+  return [node.key, ...(node.children?.flatMap(collectNodeKeys) ?? [])];
+}
+
+function PermissionTreeNode({
+  node,
+  depth,
+  selectedKeys,
+  onToggle,
+}: {
+  node: PermissionNode;
+  depth: number;
+  selectedKeys: Set<string>;
+  onToggle: (node: PermissionNode, checked: boolean) => void;
+}) {
+  const nodeKeys = useMemo(() => collectNodeKeys(node), [node]);
+  const selectedCount = nodeKeys.filter((key) => selectedKeys.has(key)).length;
+  const checked = selectedCount === nodeKeys.length;
+  const indeterminate = selectedCount > 0 && selectedCount < nodeKeys.length;
+
+  return (
+    <Box sx={{ pl: depth * 2 }}>
+      <FormControlLabel
+        control={
+          <Checkbox
+            checked={checked}
+            indeterminate={indeterminate}
+            onChange={(_, nextChecked) => onToggle(node, nextChecked)}
+          />
+        }
+        label={
+          <Typography variant="body2" sx={{ fontWeight: depth === 0 ? 600 : 400 }}>
+            {node.title}
+          </Typography>
+        }
+        sx={{ alignItems: 'flex-start', mr: 0 }}
+      />
+      <Stack spacing={0.25}>
+        {node.children?.map((child) => (
+          <PermissionTreeNode
+            key={child.key}
+            node={child}
+            depth={depth + 1}
+            selectedKeys={selectedKeys}
+            onToggle={onToggle}
+          />
+        ))}
+      </Stack>
+    </Box>
+  );
+}
+
 const RolePage: React.FC = () => {
   const [roles, setRoles] = useState<Role[]>([]);
   const [loading, setLoading] = useState(false);
   const [formVisible, setFormVisible] = useState(false);
+  const [submitLoading, setSubmitLoading] = useState(false);
 
-  // Permission assignment
   const [permModalVisible, setPermModalVisible] = useState(false);
   const [permissionsTree, setPermissionsTree] = useState<PermissionNode[]>([]);
-  const [checkedKeys, setCheckedKeys] = useState<React.Key[]>([]);
+  const [checkedKeys, setCheckedKeys] = useState<string[]>([]);
   const [currentRole, setCurrentRole] = useState<Role | null>(null);
   const [permLoading, setPermLoading] = useState(false);
+
+  const checkedKeySet = useMemo(() => new Set(checkedKeys), [checkedKeys]);
 
   const fetchRoles = useCallback(async () => {
     setLoading(true);
@@ -49,16 +116,31 @@ const RolePage: React.FC = () => {
       const res = await getPermissionsTree();
       setPermissionsTree(res.data);
     } catch {
-      // silent
+      setPermissionsTree([]);
     }
     setPermModalVisible(true);
+  };
+
+  const handlePermToggle = (node: PermissionNode, checked: boolean) => {
+    const nodeKeys = collectNodeKeys(node);
+    setCheckedKeys((previous) => {
+      const next = new Set(previous);
+      nodeKeys.forEach((key) => {
+        if (checked) {
+          next.add(key);
+        } else {
+          next.delete(key);
+        }
+      });
+      return Array.from(next);
+    });
   };
 
   const handlePermSubmit = async () => {
     if (!currentRole) return;
     setPermLoading(true);
     try {
-      await updateRolePermissions(currentRole.id, checkedKeys as string[]);
+      await updateRolePermissions(currentRole.id, checkedKeys);
       message.success('权限更新成功');
       setPermModalVisible(false);
       fetchRoles();
@@ -69,86 +151,104 @@ const RolePage: React.FC = () => {
     }
   };
 
-  const columns: ColumnsType<Role> = [
+  const columns: AppTableColumn<Role>[] = [
     { title: '角色标识', dataIndex: 'name', width: 150 },
     { title: '角色名称', dataIndex: 'display_name', width: 150 },
     { title: '描述', dataIndex: 'description', ellipsis: true },
-    { title: '创建时间', dataIndex: 'created_at', render: formatDateTime, width: 170 },
+    {
+      title: '创建时间',
+      dataIndex: 'created_at',
+      render: (value) => formatDateTime(value as string | null | undefined),
+      width: 170,
+    },
     {
       title: '操作',
       key: 'actions',
       width: 150,
       render: (_, record) => (
-        <Space>
-          <PermissionGuard permission="role:manage">
-            <Button
-              type="link"
-              size="small"
-              icon={<SettingOutlined />}
-              onClick={() => openPermModal(record)}
-            >
-              配置权限
-            </Button>
-          </PermissionGuard>
-        </Space>
+        <PermissionGuard permission="role:manage">
+          <Button
+            size="small"
+            variant="text"
+            startIcon={<ManageAccountsRoundedIcon fontSize="small" />}
+            onClick={() => openPermModal(record)}
+          >
+            配置权限
+          </Button>
+        </PermissionGuard>
       ),
     },
   ];
 
   return (
     <>
-      <div style={{ marginBottom: 16, display: 'flex', justifyContent: 'flex-end' }}>
-        <PermissionGuard permission="role:manage">
-          <Button type="primary" icon={<PlusOutlined />} onClick={() => setFormVisible(true)}>
-            新增角色
-          </Button>
-        </PermissionGuard>
-      </div>
-
-      <Table<Role>
+      <AppTable<Role>
         columns={columns}
         dataSource={roles}
         loading={loading}
-        rowKey="id"
         pagination={false}
+        toolbar={
+          <PermissionGuard permission="role:manage">
+            <Button variant="contained" startIcon={<AddRoundedIcon />} onClick={() => setFormVisible(true)}>
+              新增角色
+            </Button>
+          </PermissionGuard>
+        }
       />
 
       <AppForm
         title="新增角色"
         visible={formVisible}
         fields={formFields}
+        confirmLoading={submitLoading}
         onSubmit={async (values) => {
-          await createRole(values as Parameters<typeof createRole>[0]);
-          message.success('创建成功');
-          setFormVisible(false);
-          fetchRoles();
+          setSubmitLoading(true);
+          try {
+            await createRole(values as Parameters<typeof createRole>[0]);
+            message.success('创建成功');
+            setFormVisible(false);
+            fetchRoles();
+          } finally {
+            setSubmitLoading(false);
+          }
         }}
         onCancel={() => setFormVisible(false)}
       />
 
-      <Modal
-        title={`配置权限 - ${currentRole?.display_name || ''}`}
+      <Dialog
         open={permModalVisible}
-        onOk={handlePermSubmit}
-        onCancel={() => setPermModalVisible(false)}
-        confirmLoading={permLoading}
-        width={480}
+        onClose={() => setPermModalVisible(false)}
+        maxWidth="sm"
+        fullWidth
       >
-        <Tree
-          checkable
-          checkedKeys={checkedKeys}
-          onCheck={(keys) => setCheckedKeys(keys as React.Key[])}
-          treeData={permissionsTree.map((node) => ({
-            key: node.key,
-            title: node.title,
-            children: node.children?.map((child) => ({
-              key: child.key,
-              title: child.title,
-            })),
-          }))}
-          defaultExpandAll
-        />
-      </Modal>
+        <DialogTitle>{`配置权限 - ${currentRole?.display_name || ''}`}</DialogTitle>
+        <DialogContent dividers>
+          <Stack spacing={1.5} sx={{ pt: 1 }}>
+            <Typography variant="body2" color="text.secondary">
+              勾选权限后将覆盖该角色现有权限。
+            </Typography>
+            <Stack spacing={0.5}>
+              {permissionsTree.map((node) => (
+                <PermissionTreeNode
+                  key={node.key}
+                  node={node}
+                  depth={0}
+                  selectedKeys={checkedKeySet}
+                  onToggle={handlePermToggle}
+                />
+              ))}
+            </Stack>
+          </Stack>
+        </DialogContent>
+        <DialogActions sx={{ px: 3, py: 2 }}>
+          <Button onClick={() => setPermModalVisible(false)} color="inherit">
+            取消
+          </Button>
+          <Button onClick={handlePermSubmit} variant="contained" disabled={permLoading}>
+            {permLoading ? '保存中...' : '确定'}
+          </Button>
+        </DialogActions>
+      </Dialog>
     </>
   );
 };

--- a/frontend/src/pages/system/UserPage.tsx
+++ b/frontend/src/pages/system/UserPage.tsx
@@ -1,8 +1,9 @@
-import React, { useState, useCallback } from 'react';
-import { Button, Tag, Space, Popconfirm, message } from 'antd';
-import { PlusOutlined, EditOutlined, DeleteOutlined } from '@ant-design/icons';
-import type { ColumnsType } from 'antd/es/table';
-import AppTable from '../../components/AppTable';
+import React, { useCallback, useState } from 'react';
+import { Button, Chip, Stack } from '@mui/material';
+import AddRoundedIcon from '@mui/icons-material/AddRounded';
+import EditRoundedIcon from '@mui/icons-material/EditRounded';
+import DeleteRoundedIcon from '@mui/icons-material/DeleteRounded';
+import AppTable, { type AppTableColumn } from '../../components/AppTable';
 import AppForm, { type FormFieldConfig } from '../../components/AppForm';
 import PermissionGuard from '../../components/PermissionGuard';
 import { useTable } from '../../hooks/useTable';
@@ -10,6 +11,7 @@ import { getUsers, createUser, updateUser, deleteUser } from '../../api/users';
 import { formatDateTime } from '../../utils/formatter';
 import type { User } from '../../types/user';
 import type { PaginationParams } from '../../types/common';
+import { message } from '../../utils/message';
 
 const createFields: FormFieldConfig[] = [
   { name: 'username', label: '用户名', required: true },
@@ -37,6 +39,7 @@ const editFields: FormFieldConfig[] = [
 const UserPage: React.FC = () => {
   const [formVisible, setFormVisible] = useState(false);
   const [editingUser, setEditingUser] = useState<User | null>(null);
+  const [submitLoading, setSubmitLoading] = useState(false);
 
   const fetchFn = useCallback(
     (params: PaginationParams & { page: number; page_size: number }) => getUsers(params),
@@ -57,6 +60,10 @@ const UserPage: React.FC = () => {
   };
 
   const handleDelete = async (id: number) => {
+    if (!window.confirm('确定删除该用户？')) {
+      return;
+    }
+
     try {
       await deleteUser(id);
       message.success('删除成功');
@@ -66,7 +73,7 @@ const UserPage: React.FC = () => {
     }
   };
 
-  const columns: ColumnsType<User> = [
+  const columns: AppTableColumn<User>[] = [
     { title: '用户名', dataIndex: 'username', width: 120 },
     { title: '姓名', dataIndex: 'real_name', width: 100 },
     { title: '手机号', dataIndex: 'phone', width: 130 },
@@ -76,16 +83,27 @@ const UserPage: React.FC = () => {
       dataIndex: 'roles',
       width: 150,
       render: (roles: User['roles']) =>
-        roles?.map((r) => <Tag key={r.id} color="blue">{r.display_name}</Tag>),
+        roles?.length ? (
+          <Stack direction="row" spacing={0.75} useFlexGap flexWrap="wrap">
+            {roles.map((r) => (
+              <Chip key={r.id} label={r.display_name} size="small" color="primary" variant="outlined" />
+            ))}
+          </Stack>
+        ) : (
+          '-'
+        ),
     },
     {
       title: '状态',
       dataIndex: 'status',
       width: 80,
       render: (status: string) => (
-        <Tag color={status === 'active' ? 'green' : 'red'}>
-          {status === 'active' ? '正常' : '禁用'}
-        </Tag>
+        <Chip
+          size="small"
+          color={status === 'active' ? 'success' : 'error'}
+          variant="outlined"
+          label={status === 'active' ? '正常' : '禁用'}
+        />
       ),
     },
     { title: '创建时间', dataIndex: 'created_at', render: formatDateTime, width: 170 },
@@ -95,23 +113,27 @@ const UserPage: React.FC = () => {
       width: 160,
       fixed: 'right',
       render: (_, record) => (
-        <Space>
+        <Stack direction="row" spacing={0.5}>
           <PermissionGuard permission="user:manage">
             <Button
-              type="link"
               size="small"
-              icon={<EditOutlined />}
+              variant="text"
+              startIcon={<EditRoundedIcon fontSize="small" />}
               onClick={() => handleEdit(record)}
             >
               编辑
             </Button>
-            <Popconfirm title="确定删除该用户？" onConfirm={() => handleDelete(record.id)}>
-              <Button type="link" size="small" danger icon={<DeleteOutlined />}>
-                删除
-              </Button>
-            </Popconfirm>
+            <Button
+              size="small"
+              variant="text"
+              color="error"
+              startIcon={<DeleteRoundedIcon fontSize="small" />}
+              onClick={() => handleDelete(record.id)}
+            >
+              删除
+            </Button>
           </PermissionGuard>
-        </Space>
+        </Stack>
       ),
     },
   ];
@@ -128,7 +150,7 @@ const UserPage: React.FC = () => {
         searchPlaceholder="搜索用户名/姓名"
         toolbar={
           <PermissionGuard permission="user:manage">
-            <Button type="primary" icon={<PlusOutlined />} onClick={handleCreate}>
+            <Button variant="contained" startIcon={<AddRoundedIcon />} onClick={handleCreate}>
               新增用户
             </Button>
           </PermissionGuard>
@@ -140,15 +162,21 @@ const UserPage: React.FC = () => {
         visible={formVisible}
         fields={editingUser ? editFields : createFields}
         initialValues={editingUser || undefined}
+        confirmLoading={submitLoading}
         onSubmit={async (values) => {
-          if (editingUser) {
-            await updateUser(editingUser.id, values as Parameters<typeof updateUser>[1]);
-          } else {
-            await createUser(values as Parameters<typeof createUser>[0]);
+          setSubmitLoading(true);
+          try {
+            if (editingUser) {
+              await updateUser(editingUser.id, values as Parameters<typeof updateUser>[1]);
+            } else {
+              await createUser(values as Parameters<typeof createUser>[0]);
+            }
+            message.success(editingUser ? '更新成功' : '创建成功');
+            setFormVisible(false);
+            refresh();
+          } finally {
+            setSubmitLoading(false);
           }
-          message.success(editingUser ? '更新成功' : '创建成功');
-          setFormVisible(false);
-          refresh();
         }}
         onCancel={() => setFormVisible(false)}
       />

--- a/frontend/src/pages/system/UserPage.tsx
+++ b/frontend/src/pages/system/UserPage.tsx
@@ -1,8 +1,9 @@
-import React, { useState, useCallback } from 'react';
-import { Button, Tag, Space, Popconfirm, message } from 'antd';
-import { PlusOutlined, EditOutlined, DeleteOutlined } from '@ant-design/icons';
-import type { ColumnsType } from 'antd/es/table';
-import AppTable from '../../components/AppTable';
+import React, { useCallback, useState } from 'react';
+import { Button, Chip, Stack } from '@mui/material';
+import AddRoundedIcon from '@mui/icons-material/AddRounded';
+import EditRoundedIcon from '@mui/icons-material/EditRounded';
+import DeleteRoundedIcon from '@mui/icons-material/DeleteRounded';
+import AppTable, { type AppTableColumn } from '../../components/AppTable';
 import AppForm, { type FormFieldConfig } from '../../components/AppForm';
 import PermissionGuard from '../../components/PermissionGuard';
 import { useTable } from '../../hooks/useTable';
@@ -10,6 +11,7 @@ import { getUsers, createUser, updateUser, deleteUser } from '../../api/users';
 import { formatDateTime } from '../../utils/formatter';
 import type { User } from '../../types/user';
 import type { PaginationParams } from '../../types/common';
+import { message } from '../../utils/message';
 
 const createFields: FormFieldConfig[] = [
   { name: 'username', label: '用户名', required: true },
@@ -37,6 +39,7 @@ const editFields: FormFieldConfig[] = [
 const UserPage: React.FC = () => {
   const [formVisible, setFormVisible] = useState(false);
   const [editingUser, setEditingUser] = useState<User | null>(null);
+  const [submitLoading, setSubmitLoading] = useState(false);
 
   const fetchFn = useCallback(
     (params: PaginationParams & { page: number; page_size: number }) => getUsers(params),
@@ -57,6 +60,10 @@ const UserPage: React.FC = () => {
   };
 
   const handleDelete = async (id: number) => {
+    if (!window.confirm('确定删除该用户？')) {
+      return;
+    }
+
     try {
       await deleteUser(id);
       message.success('删除成功');
@@ -66,7 +73,7 @@ const UserPage: React.FC = () => {
     }
   };
 
-  const columns: ColumnsType<User> = [
+  const columns: AppTableColumn<User>[] = [
     { title: '用户名', dataIndex: 'username', width: 120 },
     { title: '姓名', dataIndex: 'real_name', width: 100 },
     { title: '手机号', dataIndex: 'phone', width: 130 },
@@ -75,43 +82,74 @@ const UserPage: React.FC = () => {
       title: '角色',
       dataIndex: 'roles',
       width: 150,
-      render: (roles: User['roles']) =>
-        roles?.map((r) => <Tag key={r.id} color="blue">{r.display_name}</Tag>),
+      render: (value) => {
+        const roles = value as User['roles'] | undefined;
+        return roles?.length ? (
+          <Stack direction="row" spacing={0.75} useFlexGap flexWrap="wrap">
+            {roles.map((r) => (
+              <Chip
+                key={r.id}
+                label={r.display_name}
+                size="small"
+                color="primary"
+                variant="outlined"
+              />
+            ))}
+          </Stack>
+        ) : (
+          '-'
+        );
+      },
     },
     {
       title: '状态',
       dataIndex: 'status',
       width: 80,
-      render: (status: string) => (
-        <Tag color={status === 'active' ? 'green' : 'red'}>
-          {status === 'active' ? '正常' : '禁用'}
-        </Tag>
-      ),
+      render: (value) => {
+        const status = String(value);
+        return (
+          <Chip
+            size="small"
+            color={status === 'active' ? 'success' : 'error'}
+            variant="outlined"
+            label={status === 'active' ? '正常' : '禁用'}
+          />
+        );
+      },
     },
-    { title: '创建时间', dataIndex: 'created_at', render: formatDateTime, width: 170 },
+    {
+      title: '创建时间',
+      dataIndex: 'created_at',
+      render: (value) => formatDateTime(value as string | null | undefined),
+      width: 170,
+    },
     {
       title: '操作',
       key: 'actions',
       width: 160,
       fixed: 'right',
       render: (_, record) => (
-        <Space>
+        <Stack direction="row" spacing={0.5}>
           <PermissionGuard permission="user:manage">
             <Button
-              type="link"
               size="small"
-              icon={<EditOutlined />}
+              variant="text"
+              startIcon={<EditRoundedIcon fontSize="small" />}
               onClick={() => handleEdit(record)}
             >
               编辑
             </Button>
-            <Popconfirm title="确定删除该用户？" onConfirm={() => handleDelete(record.id)}>
-              <Button type="link" size="small" danger icon={<DeleteOutlined />}>
-                删除
-              </Button>
-            </Popconfirm>
+            <Button
+              size="small"
+              variant="text"
+              color="error"
+              startIcon={<DeleteRoundedIcon fontSize="small" />}
+              onClick={() => handleDelete(record.id)}
+            >
+              删除
+            </Button>
           </PermissionGuard>
-        </Space>
+        </Stack>
       ),
     },
   ];
@@ -128,7 +166,7 @@ const UserPage: React.FC = () => {
         searchPlaceholder="搜索用户名/姓名"
         toolbar={
           <PermissionGuard permission="user:manage">
-            <Button type="primary" icon={<PlusOutlined />} onClick={handleCreate}>
+            <Button variant="contained" startIcon={<AddRoundedIcon />} onClick={handleCreate}>
               新增用户
             </Button>
           </PermissionGuard>
@@ -140,15 +178,21 @@ const UserPage: React.FC = () => {
         visible={formVisible}
         fields={editingUser ? editFields : createFields}
         initialValues={editingUser || undefined}
+        confirmLoading={submitLoading}
         onSubmit={async (values) => {
-          if (editingUser) {
-            await updateUser(editingUser.id, values as Parameters<typeof updateUser>[1]);
-          } else {
-            await createUser(values as Parameters<typeof createUser>[0]);
+          setSubmitLoading(true);
+          try {
+            if (editingUser) {
+              await updateUser(editingUser.id, values as Parameters<typeof updateUser>[1]);
+            } else {
+              await createUser(values as Parameters<typeof createUser>[0]);
+            }
+            message.success(editingUser ? '更新成功' : '创建成功');
+            setFormVisible(false);
+            refresh();
+          } finally {
+            setSubmitLoading(false);
           }
-          message.success(editingUser ? '更新成功' : '创建成功');
-          setFormVisible(false);
-          refresh();
         }}
         onCancel={() => setFormVisible(false)}
       />

--- a/frontend/src/router/index.tsx
+++ b/frontend/src/router/index.tsx
@@ -1,6 +1,6 @@
 import React, { lazy, Suspense } from 'react';
+import { Box, CircularProgress } from '@mui/material';
 import { Routes, Route, Navigate } from 'react-router-dom';
-import { Spin } from 'antd';
 import BasicLayout from '../layouts/BasicLayout';
 import BlankLayout from '../layouts/BlankLayout';
 import { useAuthStore, getHomeRoute } from '../store/auth';
@@ -31,9 +31,9 @@ const FamilyElderHealthPage = lazy(() => import('../pages/family-portal/FamilyEl
 
 /** Loading fallback for lazy-loaded pages */
 const PageLoading: React.FC = () => (
-  <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '50vh' }}>
-    <Spin size="large" />
-  </div>
+  <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: '50vh' }}>
+    <CircularProgress size={42} />
+  </Box>
 );
 
 /** Protected route wrapper — redirects to login if no token */

--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -1,10 +1,7 @@
-/* Global styles and Ant Design overrides */
-
 body {
-  background-color: #f5f5f5;
+  color: #0f172a;
 }
 
-/* Scrollbar styling */
 ::-webkit-scrollbar {
   width: 6px;
   height: 6px;
@@ -17,26 +14,4 @@ body {
 
 ::-webkit-scrollbar-track {
   background: transparent;
-}
-
-/* Card hover effect */
-.ant-card:hover {
-  transition: box-shadow 0.3s;
-}
-
-/* Table row hover */
-.ant-table-tbody > tr:hover > td {
-  transition: background 0.2s;
-}
-
-/* Page transition */
-.page-enter {
-  opacity: 0;
-  transform: translateY(8px);
-}
-
-.page-enter-active {
-  opacity: 1;
-  transform: translateY(0);
-  transition: opacity 0.3s, transform 0.3s;
 }

--- a/frontend/src/styles/reset.css
+++ b/frontend/src/styles/reset.css
@@ -9,9 +9,6 @@
 html,
 body {
   height: 100%;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
-    'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji',
-    'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }

--- a/frontend/src/theme.ts
+++ b/frontend/src/theme.ts
@@ -1,0 +1,108 @@
+import { createTheme } from '@mui/material/styles';
+import { zhCN } from '@mui/material/locale';
+
+const theme = createTheme(
+  {
+    palette: {
+      mode: 'light',
+      primary: {
+        main: '#1f6feb',
+        dark: '#174fb6',
+        light: '#6aa7ff',
+      },
+      secondary: {
+        main: '#0f9d8f',
+        dark: '#0b6f65',
+        light: '#58c7bc',
+      },
+      background: {
+        default: '#f3f7fb',
+        paper: '#ffffff',
+      },
+      success: {
+        main: '#1f9d63',
+      },
+      warning: {
+        main: '#d9822b',
+      },
+      error: {
+        main: '#d14343',
+      },
+    },
+    shape: {
+      borderRadius: 16,
+    },
+    typography: {
+      fontFamily: [
+        '"Noto Sans SC"',
+        '"PingFang SC"',
+        '"Microsoft YaHei"',
+        '"Helvetica Neue"',
+        'sans-serif',
+      ].join(','),
+      h4: {
+        fontWeight: 700,
+        letterSpacing: '-0.02em',
+      },
+      h5: {
+        fontWeight: 700,
+      },
+      h6: {
+        fontWeight: 700,
+      },
+      button: {
+        fontWeight: 600,
+        textTransform: 'none',
+      },
+    },
+    components: {
+      MuiCssBaseline: {
+        styleOverrides: {
+          body: {
+            background:
+              'radial-gradient(circle at top, rgba(31, 111, 235, 0.1), transparent 30%), #f3f7fb',
+          },
+        },
+      },
+      MuiPaper: {
+        styleOverrides: {
+          root: {
+            backgroundImage: 'none',
+          },
+        },
+      },
+      MuiCard: {
+        styleOverrides: {
+          root: {
+            borderRadius: 20,
+            boxShadow: '0 16px 40px rgba(15, 23, 42, 0.08)',
+          },
+        },
+      },
+      MuiButton: {
+        styleOverrides: {
+          root: {
+            borderRadius: 999,
+          },
+        },
+      },
+      MuiOutlinedInput: {
+        styleOverrides: {
+          root: {
+            borderRadius: 14,
+          },
+        },
+      },
+      MuiChip: {
+        styleOverrides: {
+          root: {
+            borderRadius: 999,
+          },
+        },
+      },
+    },
+  },
+  zhCN,
+);
+
+export default theme;

--- a/frontend/src/types/mui-icons.d.ts
+++ b/frontend/src/types/mui-icons.d.ts
@@ -1,0 +1,1 @@
+declare module '@mui/icons-material/*';

--- a/frontend/src/utils/message.ts
+++ b/frontend/src/utils/message.ts
@@ -39,5 +39,7 @@ export const message = {
 
 export function subscribeMessage(listener: MessageListener) {
   listeners.add(listener);
-  return () => listeners.delete(listener);
+  return () => {
+    listeners.delete(listener);
+  };
 }

--- a/frontend/src/utils/message.ts
+++ b/frontend/src/utils/message.ts
@@ -1,0 +1,43 @@
+type MessageType = 'success' | 'error' | 'warning' | 'info';
+
+interface MessageEvent {
+  id: number;
+  type: MessageType;
+  content: string;
+  duration: number;
+}
+
+type MessageListener = (event: MessageEvent) => void;
+
+const listeners = new Set<MessageListener>();
+
+function emit(type: MessageType, content: string, duration = 3000) {
+  const event: MessageEvent = {
+    id: Date.now() + Math.random(),
+    type,
+    content,
+    duration,
+  };
+
+  listeners.forEach((listener) => listener(event));
+}
+
+export const message = {
+  success(content: string, duration?: number) {
+    emit('success', content, duration);
+  },
+  error(content: string, duration?: number) {
+    emit('error', content, duration ?? 4000);
+  },
+  warning(content: string, duration?: number) {
+    emit('warning', content, duration);
+  },
+  info(content: string, duration?: number) {
+    emit('info', content, duration);
+  },
+};
+
+export function subscribeMessage(listener: MessageListener) {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}


### PR DESCRIPTION
## Summary
- Scaffold MUI app shell with theme configuration and layout components
- Migrate admin, monitoring, portal, and elder domain pages from Ant Design to Material UI
- Finalize MUI build integration with updated dependencies and type definitions

## Changes
- 45 files changed, 5392 insertions, 3171 deletions
- Replaces Ant Design components with MUI equivalents across all frontend pages
- Adds custom MUI theme (`theme.ts`) and message utility (`utils/message.ts`)
- Updates build config and TypeScript declarations for MUI compatibility

## Test plan
- [ ] Verify all migrated pages render correctly with MUI components
- [ ] Check responsive layout on mobile and desktop viewports
- [ ] Confirm no Ant Design remnants in the bundle
- [ ] Test login, dashboard, elder management, and admin flows end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)